### PR TITLE
feat: snooze button, task detail sync, delete button, AI enrichment cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 </p>
 
 > [!NOTE]
-> 🚧 **Early public release — looking for testers and contributors!** 🎉
+> **Early release** — Please bear with the rough edges. 👷 Expect occasional bugs and other issues as things get ironed out. Please [open an issue](https://github.com/trentmcnitt/opentask/issues) if you run into any problems.
 
 OpenTask is a self-hosted task manager I built for personal use. I've been using it daily, and it's reached a point where I'm excited to open it up.
 

--- a/ios/OpenTaskNotification/SnoozeGridView.swift
+++ b/ios/OpenTaskNotification/SnoozeGridView.swift
@@ -83,7 +83,7 @@ struct SnoozeGridView: View {
 
     private let increments: [IncrementButton] = [
         IncrementButton(id: "i-1", label: "+1 min", minutes: 1, days: nil),
-        IncrementButton(id: "i-30", label: "+30 min", minutes: 30, days: nil),
+        IncrementButton(id: "i-10", label: "+10 min", minutes: 10, days: nil),
         IncrementButton(id: "i-60", label: "+1 hr", minutes: 60, days: nil),
         IncrementButton(id: "i-1d", label: "+1 day", minutes: nil, days: 1),
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentask",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "engines": {
     "node": ">=20.0.0"

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -32,6 +32,7 @@ import type { SingleTaskActionsReturn } from '@/hooks/useTaskActions'
 import { useAiInsights } from '@/hooks/useAiInsights'
 import { useInsightsData } from '@/hooks/useInsightsData'
 import { useUndoRedoShortcuts } from '@/hooks/useUndoRedoShortcuts'
+import { useSyncStream, type EnrichmentCompleteData } from '@/hooks/useSyncStream'
 
 export default function TaskDetailPage() {
   const { status } = useSession()
@@ -54,12 +55,8 @@ export default function TaskDetailPage() {
     useNavigationGuard()
   const saveRef = useRef<(() => Promise<void> | void) | null>(null)
 
-  const handleDirtyChange = useCallback(
-    (dirty: boolean) => {
-      setDirty(dirty)
-    },
-    [setDirty],
-  )
+  const isDirtyRef = useRef(false)
+  const pendingRefreshRef = useRef(false)
 
   // Clean up guard registration on unmount
   useEffect(() => {
@@ -106,6 +103,9 @@ export default function TaskDetailPage() {
     router.push(href)
   }, [pendingNavigation, clearPendingNavigation, router])
 
+  const numericTaskId = Number(taskId)
+
+  // Full fetch (task + projects) for initial load and explicit user actions
   const fetchTask = useCallback(async () => {
     try {
       const [taskRes, projRes] = await Promise.all([
@@ -138,6 +138,40 @@ export default function TaskDetailPage() {
     }
   }, [taskId, router])
 
+  // Task-only refresh for SSE sync events (projects rarely change)
+  const refreshTask = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`)
+      if (!res.ok) return
+      const data = await res.json()
+      setTask(data.data as Task)
+    } catch {
+      // Silently ignore sync refresh failures — next sync will retry
+    }
+  }, [taskId])
+
+  // Refresh or defer based on dirty state. When dirty, queues a refresh
+  // that fires when the panel becomes clean (save or cancel).
+  const refreshOrDefer = useCallback(() => {
+    if (!isDirtyRef.current) {
+      refreshTask()
+    } else {
+      pendingRefreshRef.current = true
+    }
+  }, [refreshTask])
+
+  const handleDirtyChange = useCallback(
+    (dirty: boolean) => {
+      isDirtyRef.current = dirty
+      setDirty(dirty)
+      if (!dirty && pendingRefreshRef.current) {
+        pendingRefreshRef.current = false
+        refreshTask()
+      }
+    },
+    [setDirty, refreshTask],
+  )
+
   useEffect(() => {
     if (status === 'loading') return
     if (status === 'unauthenticated') {
@@ -157,6 +191,24 @@ export default function TaskDetailPage() {
   }) as SingleTaskActionsReturn
 
   useUndoRedoShortcuts(actions.handleUndoRef, actions.handleRedoRef)
+
+  // Real-time sync: refresh task data when changes arrive from other tabs/enrichment.
+  // Defers refresh while the user has unsaved edits to avoid losing their work.
+  const handleEnrichmentComplete = useCallback(
+    (data: EnrichmentCompleteData) => {
+      if (data.taskId !== numericTaskId) return
+      refreshOrDefer()
+      if (isDirtyRef.current) {
+        showToast({ message: `AI enriched: ${data.title}`, type: 'success' })
+      }
+    },
+    [refreshOrDefer, numericTaskId],
+  )
+
+  useSyncStream({
+    onSync: refreshOrDefer,
+    onEnrichmentComplete: handleEnrichmentComplete,
+  })
 
   // Keep handleSaveAndLeave's undo ref in sync with the shared handler
   handleUndoRef.current = actions.handleUndo

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -284,7 +284,7 @@ export function Header({
             {/* Snooze all overdue button - desktop only (mobile uses FAB).
                Single click: snooze using default duration.
                Long-press (400ms): opens SnoozeMenu with duration choices. */}
-            {onSnoozeOverdue && overdueCount > 0 && !isSelectionMode && (
+            {onSnoozeOverdue && !isSelectionMode && (
               <SnoozeMenu
                 open={snoozeMenuOpen}
                 onOpenChange={setSnoozeMenuOpen}
@@ -297,13 +297,19 @@ export function Header({
                   onPointerDown={snoozePress.onPointerDown}
                   onPointerUp={snoozePress.onPointerUp}
                   onPointerLeave={snoozePress.onPointerLeave}
-                  aria-label={`Snooze ${overdueCount} overdue tasks (hold for options)`}
+                  aria-label={
+                    overdueCount > 0
+                      ? `Snooze ${overdueCount} overdue tasks (hold for options)`
+                      : 'Snooze overdue tasks (hold for options)'
+                  }
                   className="relative hidden md:inline-flex"
                 >
                   <Clock className="size-5" />
-                  <span className="bg-badge-destructive text-destructive-foreground absolute top-0 right-0 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-bold">
-                    {overdueCount > 999 ? '999+' : overdueCount}
-                  </span>
+                  {overdueCount > 0 && (
+                    <span className="bg-badge-destructive text-destructive-foreground absolute top-0 right-0 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-bold">
+                      {overdueCount > 999 ? '999+' : overdueCount}
+                    </span>
+                  )}
                   <span className="bg-muted text-muted-foreground absolute right-0 bottom-0 rounded px-0.5 text-[8px] leading-tight font-medium">
                     {formatCompactSnoozeLabel(defaultSnoozeOption)}
                   </span>

--- a/src/components/QuickActionPopover.tsx
+++ b/src/components/QuickActionPopover.tsx
@@ -124,7 +124,7 @@ export function QuickActionPopover({
       )}
     >
       <QuickActionPanel
-        key={focusedTask.updated_at}
+        key={focusedTask.id}
         task={focusedTask}
         timezone={timezone}
         mode={isMobile ? 'sheet' : 'popover'}

--- a/src/components/SelectionActionSheet.tsx
+++ b/src/components/SelectionActionSheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
-import { Check, X, FileText } from 'lucide-react'
+import { Check, X, FileText, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Sheet,
@@ -496,6 +496,15 @@ export function SelectionActionSheet({
 
           <Button size="sm" variant="secondary" onClick={openSheet}>
             More
+          </Button>
+
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={handleDelete}
+            aria-label={`Delete ${selectedCount} ${taskWord(selectedCount)}`}
+          >
+            <Trash2 className="size-4" />
           </Button>
 
           <Button

--- a/src/components/SnoozeAllFab.tsx
+++ b/src/components/SnoozeAllFab.tsx
@@ -29,7 +29,7 @@ export function SnoozeAllFab({
     onShortPress: () => onSnoozeOverdue(),
   })
 
-  if (overdueCount === 0 || isSelectionMode) return null
+  if (isSelectionMode) return null
 
   return (
     <SnoozeMenu
@@ -42,13 +42,19 @@ export function SnoozeAllFab({
         onPointerDown={press.onPointerDown}
         onPointerUp={press.onPointerUp}
         onPointerLeave={press.onPointerLeave}
-        aria-label={`Snooze ${overdueCount} overdue tasks (hold for options)`}
+        aria-label={
+          overdueCount > 0
+            ? `Snooze ${overdueCount} overdue tasks (hold for options)`
+            : 'Snooze overdue tasks (hold for options)'
+        }
         className="fixed right-4 bottom-[calc(env(safe-area-inset-bottom,0px)+4.5rem)] z-40 flex size-12 items-center justify-center rounded-full bg-blue-500 text-white shadow-lg shadow-blue-500/25 transition-colors hover:bg-blue-600 active:bg-blue-700 md:hidden"
       >
         <Clock className="size-5" />
-        <span className="bg-badge-destructive text-destructive-foreground absolute -top-1 -right-1 flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[10px] font-bold">
-          {overdueCount > 999 ? '999+' : overdueCount}
-        </span>
+        {overdueCount > 0 && (
+          <span className="bg-badge-destructive text-destructive-foreground absolute -top-1 -right-1 flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[10px] font-bold">
+            {overdueCount > 999 ? '999+' : overdueCount}
+          </span>
+        )}
       </button>
     </SnoozeMenu>
   )

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -80,7 +80,7 @@ export function TaskDetail({
             )}
           >
             <QuickActionPanel
-              key={task.updated_at}
+              key={task.id}
               task={task}
               timezone={timezone}
               mode="popover"

--- a/src/core/tasks/update.ts
+++ b/src/core/tasks/update.ts
@@ -120,6 +120,17 @@ export function updateTask(options: UpdateTaskOptions): UpdateTaskResult {
     return { task: updatedTask, fieldsChanged: data.fieldsChanged, description }
   })
 
+  // Cancel pending AI enrichment — user's manual edit takes precedence.
+  // Done outside the transaction: not a user-visible change, not part of undo snapshot.
+  // If the user undoes their edit, ai-to-process is restored and enrichment can resume.
+  if (result.task.labels.includes('ai-to-process')) {
+    const cleanedLabels = result.task.labels.filter((l) => l !== 'ai-to-process')
+    getDb()
+      .prepare('UPDATE tasks SET labels = ? WHERE id = ?')
+      .run(JSON.stringify(cleanedLabels), taskId)
+    result.task.labels = cleanedLabels
+  }
+
   emitSyncEvent(userId)
 
   // Callers like snoozeTask() set skipWebhookDispatch to dispatch their own more specific event

--- a/src/lib/quick-select-dates.ts
+++ b/src/lib/quick-select-dates.ts
@@ -25,7 +25,7 @@ export const PRESET_TIMES = [
 /** Increment buttons: positive = forward, negative = backward */
 export const INCREMENTS = [
   { label: '+1 min', minutes: 1 },
-  { label: '+30 min', minutes: 30 },
+  { label: '+10 min', minutes: 10 },
   { label: '+1 hr', minutes: 60 },
   { label: '+1 day', minutes: null, days: 1 },
 ] as const


### PR DESCRIPTION
## Summary
- **Always show snooze button** — removes dependency on stale `overdueCount` computed in `useMemo`; badge only appears when overdue tasks exist, action handler shows toast if nothing is overdue
- **Task detail real-time sync** — wire up SSE sync stream so the task detail page receives live updates; defers refresh while user has unsaved edits; change QuickActionPanel key from `updated_at` to `id` to prevent forced remount mid-edit
- **Delete button on selection bar** — surface a dedicated trash button so users can bulk-delete without opening the More sheet
- **Cancel AI enrichment on manual edit** — remove `ai-to-process` label after `updateTask` so enrichment doesn't overwrite manual changes; undo restores the label

## Test plan
- [x] `npm run type-check && npm run lint && npm test` — all pass
- [ ] `npm run test:e2e`
- [ ] Verify snooze button visible on desktop/mobile with 0 overdue tasks
- [ ] Verify snooze toast "No overdue tasks" when tapped with nothing overdue
- [ ] Verify task detail page updates when task is edited from another tab
- [ ] Verify bulk delete from selection bar works

🤖 Generated with [Claude Code](https://claude.com/claude-code)