### PR TITLE
Auto-assign new issues to trentmcnitt (fixes missed mobile notifications)

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,19 @@
+name: Auto-assign new issues
+on:
+  issues:
+    types: [opened]
+permissions:
+  issues: write
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['trentmcnitt']
+            });


### PR DESCRIPTION
Auto-assigns every newly opened issue to @trentmcnitt. Assignment is one of the four event types GitHub Mobile pushes, so this ensures new issues trigger a phone notification instead of silently landing in the inbox.