### PR TITLE
Stage 2 (server) + Stage 3: Reminders backend, slot dashboard, cadence ladder

### DIFF
--- a/scripts/classify-recurring.ts
+++ b/scripts/classify-recurring.ts
@@ -1,0 +1,228 @@
+/**
+ * §9 migration — classification pass (DRY RUN ONLY)
+ *
+ * Sorts the recurring corpus into the four §3 populations and prints a review
+ * list. **This script never writes.** §9 puts one human gate in front of the
+ * migration, and this is the artifact that gate reviews.
+ *
+ * The four populations:
+ *   protocol       → stays a task, lands in a time slot (§7)
+ *   prompted       → is_reminder = 1, moves to the Reminders surface (§6)
+ *   parked-one-off → rrule REMOVED and a real due_at PATCHED in (§9.1)
+ *   quota          → progress_target parsed from the title (§5)
+ *
+ * §9.1 is the trap worth restating: clearing `rrule` alone does NOT refresh
+ * `due_at`. `collect-field-changes.ts` leaves it at its last stale sweep value,
+ * which is exactly the untrustworthy state §4.6 warns about — made permanent.
+ * So every parked one-off MUST carry a produced due_at, and this script fails
+ * loudly if one doesn't.
+ *
+ * Usage:
+ *   npx tsx scripts/classify-recurring.ts <db-path> [--json out.json]
+ */
+
+import Database from 'better-sqlite3'
+import fs from 'node:fs'
+
+interface Row {
+  id: number
+  title: string
+  due_at: string | null
+  rrule: string
+  anchor_time: string | null
+  priority: number
+  completion_count: number
+  project: string
+  labels: string
+}
+
+type Population = 'protocol' | 'prompted' | 'parked-one-off' | 'quota'
+
+interface Classification {
+  id: number
+  title: string
+  population: Population
+  reason: string
+  /** For quotas: the N parsed from the title. */
+  target?: number
+  /** For quotas: the period the N applies to. */
+  period?: string
+  confidence: 'high' | 'low'
+}
+
+const dbPath = process.argv[2]
+if (!dbPath) {
+  console.error('usage: classify-recurring.ts <db-path> [--json out.json]')
+  process.exit(1)
+}
+
+const db = new Database(dbPath, { readonly: true })
+
+const rows = db
+  .prepare(
+    `SELECT t.id, t.title, t.due_at, t.rrule, t.anchor_time, t.priority,
+            t.completion_count, t.labels, p.name AS project
+       FROM tasks t
+       JOIN users u ON u.id = t.user_id
+       LEFT JOIN projects p ON p.id = t.project_id
+      WHERE u.name = 'Trent'
+        AND t.done = 0 AND t.deleted_at IS NULL AND t.archived_at IS NULL
+        AND t.rrule IS NOT NULL
+      ORDER BY p.name, t.title`,
+  )
+  .all() as Row[]
+
+/**
+ * Quota titles encode their target inline: "Eggs (2x/week)", "Beef For Kids
+ * 4x/week". Matching the number AND the period is what makes this safe to
+ * automate — a title with a bare number is not evidence of a quota.
+ */
+const QUOTA_RE = /(\d+)\s*x\s*\/?\s*(day|daily|week|weekly|month|monthly)/i
+
+/**
+ * Prompted thoughts are principles, not actions.
+ *
+ * DO NOT use the bracket prefixes for this. They encode TIME OF DAY, not kind:
+ * [M]=morning, [A]=afternoon (all anchored 16:00), [E]=evening, [N]=night,
+ * [EM]=early morning. An earlier version of this script read [A] as
+ * "considerations" and mislabelled all 28 afternoon tasks as thoughts.
+ *
+ * Worse, kind is MIXED WITHIN a prefix — "[A] Being loving is a much happier
+ * way to live" and "[A] Kids gymnastics" share a prefix and are different
+ * populations. Kind is simply not derivable from structure here, which is
+ * exactly why §9 specifies an AI classification pass. What follows is a
+ * shape heuristic: it finds titles phrased as a statement rather than an
+ * instruction, and everything it flags is low-confidence by construction.
+ */
+const PROMPTED_HINTS = [
+  /\bremember\b/i,
+  /\bconsider\b/i,
+  /=\s*(past|future|peace)/i,
+  /\bmindset\b/i,
+  /\bprinciple\b/i,
+  // Statement-shaped: contains a copula, which an instruction rarely does.
+  /\b(is|are|means|isn't|aren't)\b.*\b(way|better|happier|enough|okay|fine|peace)\b/i,
+  /\byou don'?t have to\b/i,
+]
+
+/**
+ * Parked one-offs are real errands wearing a fake daily rrule because
+ * recurrence was the only resurfacing mechanism available. The signature is a
+ * one-shot verb — you register a car once.
+ */
+const ONE_OFF_HINTS = [
+  /\bregister\b/i,
+  /\be-?sign\b/i,
+  /\brenew\b/i,
+  /\bcancel\b/i,
+  /\bschedule\b.*\bappointment\b/i,
+  /\bfile\b.*\b(taxes|claim)\b/i,
+  /\bset up\b/i,
+  /\bbuy\b(?!.*\bweekly\b)/i,
+]
+
+function classify(row: Row): Classification {
+  const quota = QUOTA_RE.exec(row.title)
+  if (quota) {
+    return {
+      id: row.id,
+      title: row.title,
+      population: 'quota',
+      target: parseInt(quota[1], 10),
+      period: quota[2].toLowerCase(),
+      reason: `title encodes ${quota[1]}x per ${quota[2]}`,
+      confidence: 'high',
+    }
+  }
+
+  if (PROMPTED_HINTS.some((re) => re.test(row.title))) {
+    return {
+      id: row.id,
+      title: row.title,
+      population: 'prompted',
+      reason: 'phrased as a thought to have, not an action to take',
+      // Never high: distinguishing a thought from an action is semantic
+      // judgement, and this is a regex.
+      confidence: 'low',
+    }
+  }
+
+  if (ONE_OFF_HINTS.some((re) => re.test(row.title))) {
+    return {
+      id: row.id,
+      title: row.title,
+      population: 'parked-one-off',
+      reason: 'one-shot verb — recurrence is standing in for resurfacing',
+      confidence: 'low',
+    }
+  }
+
+  return {
+    id: row.id,
+    title: row.title,
+    population: 'protocol',
+    reason: 'discrete repeatable action with a time of day',
+    // Everything falls here by default, so it is never high-confidence on its
+    // own — this is the bucket the human review actually has to read.
+    confidence: 'low',
+  }
+}
+
+const results = rows.map(classify)
+
+const byPopulation = new Map<Population, Classification[]>()
+for (const r of results) {
+  if (!byPopulation.has(r.population)) byPopulation.set(r.population, [])
+  byPopulation.get(r.population)!.push(r)
+}
+
+const ORDER: Population[] = ['quota', 'prompted', 'parked-one-off', 'protocol']
+
+console.log('='.repeat(78))
+console.log('§9 MIGRATION — CLASSIFICATION REVIEW LIST (DRY RUN, NOTHING WRITTEN)')
+console.log('='.repeat(78))
+console.log(`\n${rows.length} active recurring tasks\n`)
+
+for (const pop of ORDER) {
+  const items = byPopulation.get(pop) ?? []
+  console.log(`\n${'-'.repeat(78)}`)
+  console.log(`${pop.toUpperCase()} — ${items.length} tasks`)
+  console.log('-'.repeat(78))
+  for (const item of items) {
+    const flag = item.confidence === 'low' ? ' ⚠ REVIEW' : ''
+    const extra = item.target ? `  [target ${item.target}/${item.period}]` : ''
+    console.log(`  #${item.id}  ${item.title.slice(0, 60)}${extra}${flag}`)
+    if (item.confidence === 'low') console.log(`        ↳ ${item.reason}`)
+  }
+}
+
+const lowConfidence = results.filter((r) => r.confidence === 'low').length
+console.log(`\n${'='.repeat(78)}`)
+console.log('SUMMARY')
+console.log('='.repeat(78))
+for (const pop of ORDER) {
+  console.log(`  ${pop.padEnd(16)} ${(byPopulation.get(pop) ?? []).length}`)
+}
+console.log(`\n  ⚠ ${lowConfidence} of ${rows.length} need a human decision.`)
+
+console.log(`
+NEXT STEPS — nothing has been written.
+
+1. Review the list above, especially the ⚠ entries.
+2. Parked one-offs each need a REAL due_at chosen. §9.1: clearing rrule alone
+   does NOT refresh due_at — it stays at its last stale sweep value, which is
+   the untrustworthy state §4.6 warns about, made permanent. The executor must
+   PATCH due_at explicitly alongside rrule: null, and will refuse to run
+   otherwise.
+3. Non-recurring Backlog (~122 tasks, 25% of the corpus) is a SEPARATE step
+   (§9.3) and is not covered by this pass.
+4. Take a sqlite3 .backup immediately before any --execute.
+`)
+
+const jsonIdx = process.argv.indexOf('--json')
+if (jsonIdx !== -1 && process.argv[jsonIdx + 1]) {
+  fs.writeFileSync(process.argv[jsonIdx + 1], JSON.stringify(results, null, 2))
+  console.log(`Wrote ${results.length} classifications to ${process.argv[jsonIdx + 1]}`)
+}
+
+db.close()

--- a/src/app/api/reminders/route.ts
+++ b/src/app/api/reminders/route.ts
@@ -1,0 +1,37 @@
+/**
+ * Reminders surface API (REDESIGN-V03 §6)
+ *
+ * GET /api/reminders - Today's incomplete reminders, grouped by time slot
+ *
+ * Reminders are prompted thoughts, not actions. They have no debt: never
+ * counted in overdue, never in the badge, never fire individually. The time
+ * slot notifies, not the item.
+ */
+
+import { NextRequest } from 'next/server'
+import { requireAuth, AuthError } from '@/core/auth'
+import { success, unauthorized, handleError } from '@/lib/api-response'
+import { getRemindersBySlot } from '@/core/tasks/reminders'
+import { formatTaskResponse } from '@/lib/format-task'
+import { log } from '@/lib/logger'
+import { withLogging } from '@/lib/with-logging'
+
+export const GET = withLogging(async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request)
+    const groups = getRemindersBySlot(user.id, user.timezone)
+
+    return success({
+      groups: groups.map((g) => ({
+        slot: g.slot,
+        reminders: g.reminders.map(formatTaskResponse),
+        count: g.reminders.length,
+      })),
+      total: groups.reduce((sum, g) => sum + g.reminders.length, 0),
+    })
+  } catch (err) {
+    if (err instanceof AuthError) return unauthorized(err.message)
+    log.error('api', 'GET /api/reminders error:', err)
+    return handleError(err)
+  }
+})

--- a/src/app/api/tasks/bulk/complete/route.ts
+++ b/src/app/api/tasks/bulk/complete/route.ts
@@ -1,0 +1,51 @@
+/**
+ * Batch complete API (REDESIGN-V03 §6.1)
+ *
+ * POST /api/tasks/bulk/complete - Complete N tasks in ONE request
+ *
+ * Built for the notification batch-checklist: the content extension stages
+ * check-marks in SwiftUI and commits them with a single action button. No such
+ * endpoint existed — the extension would otherwise have to fire N requests from
+ * a context that can be suspended mid-flight, which is exactly how you get a
+ * half-applied checklist and a user who stops trusting the notification.
+ *
+ * Delegates to bulkDone(), so this is one transaction and ONE undo entry: an
+ * accidental commit is a single undo away, not N.
+ */
+
+import { NextRequest } from 'next/server'
+import { requireAuth, AuthError } from '@/core/auth'
+import { success, unauthorized, handleError, handleZodError } from '@/lib/api-response'
+import { bulkDone } from '@/core/tasks'
+import { dismissNotificationsForTasks } from '@/core/notifications/dismiss'
+import { validateBulkDone } from '@/core/validation'
+import { log } from '@/lib/logger'
+import { withLogging } from '@/lib/with-logging'
+import { ZodError } from 'zod'
+
+export const POST = withLogging(async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request)
+    const input = validateBulkDone(await request.json())
+
+    const result = bulkDone({
+      userId: user.id,
+      userTimezone: user.timezone,
+      taskIds: input.ids,
+    })
+
+    // The items are handled, so their banners should go too.
+    dismissNotificationsForTasks(user.id, input.ids)
+
+    return success({
+      tasks_affected: result.tasksAffected,
+      recurring_count: result.recurringCount,
+      one_off_count: result.oneOffCount,
+    })
+  } catch (err) {
+    if (err instanceof AuthError) return unauthorized(err.message)
+    if (err instanceof ZodError) return handleZodError(err)
+    log.error('api', 'POST /api/tasks/bulk/complete error:', err)
+    return handleError(err)
+  }
+})

--- a/src/app/api/tasks/bulk/snooze-overdue/route.ts
+++ b/src/app/api/tasks/bulk/snooze-overdue/route.ts
@@ -98,6 +98,9 @@ export const POST = withLogging(async function POST(request: NextRequest) {
       tasks_affected: result.tasksAffected,
       tasks_skipped: result.tasksSkipped,
       skipped_urgent: result.urgentSkipped,
+      // §6: reminders are bucket-locked, so a sweep reports them rather than
+      // prompting about them.
+      skipped_reminders: result.reminderSkipped,
     })
   } catch (err) {
     if (err instanceof AuthError) {

--- a/src/app/api/tasks/bulk/snooze/route.ts
+++ b/src/app/api/tasks/bulk/snooze/route.ts
@@ -44,6 +44,9 @@ export const POST = withLogging(async function POST(request: NextRequest) {
       tasks_affected: result.tasksAffected,
       tasks_skipped: result.tasksSkipped,
       skipped_urgent: result.urgentSkipped,
+      // §6: reminders are bucket-locked, so a sweep reports them rather than
+      // prompting about them.
+      skipped_reminders: result.reminderSkipped,
       skipped_no_due_date: result.noDueDateSkipped,
     })
   } catch (err) {

--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -202,6 +202,25 @@ function validateGeneralFields(
     params.push(val)
   }
 
+  // §4.1 cadence ladder
+  if (body.auto_snooze_low_minutes !== undefined) {
+    const val = body.auto_snooze_low_minutes
+    // Ceiling is 1440 (24h), not 360 like the upper tiers: P1 is deliberately
+    // rare, so "a few times a day" must be expressible.
+    if (typeof val !== 'number' || !Number.isInteger(val) || val < 1 || val > 1440)
+      return 'auto_snooze_low_minutes must be an integer between 1 and 1440'
+    updates.push('auto_snooze_low_minutes = ?')
+    params.push(val)
+  }
+
+  if (body.auto_snooze_medium_minutes !== undefined) {
+    const val = body.auto_snooze_medium_minutes
+    if (typeof val !== 'number' || !Number.isInteger(val) || val < 1 || val > 1440)
+      return 'auto_snooze_medium_minutes must be an integer between 1 and 1440'
+    updates.push('auto_snooze_medium_minutes = ?')
+    params.push(val)
+  }
+
   if (body.auto_snooze_high_minutes !== undefined) {
     const val = body.auto_snooze_high_minutes
     if (typeof val !== 'number' || !Number.isInteger(val) || val < 1 || val > 360)
@@ -411,7 +430,7 @@ function validatePatchFields(body: Record<string, unknown>): ValidatedPatch | st
 }
 
 const PREFERENCES_SELECT =
-  'SELECT default_grouping, default_sort, default_sort_reversed, label_config, priority_display, auto_snooze_minutes, auto_snooze_urgent_minutes, auto_snooze_high_minutes, default_snooze_option, morning_time, wake_time, sleep_time, notifications_enabled, critical_alert_volume, ai_context, ai_mode, ai_show_scores, ai_show_signals, ai_enrichment_mode, ai_quicktake_mode, ai_whats_next_mode, ai_insights_mode, ai_wn_commentary_unfiltered, ai_wn_highlight, ai_insights_signal_chips, ai_insights_score_chips, ai_enrichment_timeout_ms, ai_quicktake_timeout_ms, ai_whats_next_timeout_ms, ai_insights_timeout_ms FROM users WHERE id = ?'
+  'SELECT default_grouping, default_sort, default_sort_reversed, label_config, priority_display, auto_snooze_minutes, auto_snooze_urgent_minutes, auto_snooze_high_minutes, auto_snooze_low_minutes, auto_snooze_medium_minutes, default_snooze_option, morning_time, wake_time, sleep_time, notifications_enabled, critical_alert_volume, ai_context, ai_mode, ai_show_scores, ai_show_signals, ai_enrichment_mode, ai_quicktake_mode, ai_whats_next_mode, ai_insights_mode, ai_wn_commentary_unfiltered, ai_wn_highlight, ai_insights_signal_chips, ai_insights_score_chips, ai_enrichment_timeout_ms, ai_quicktake_timeout_ms, ai_whats_next_timeout_ms, ai_insights_timeout_ms FROM users WHERE id = ?'
 
 interface PreferencesRow {
   default_grouping: string
@@ -422,6 +441,8 @@ interface PreferencesRow {
   auto_snooze_minutes: number
   auto_snooze_urgent_minutes: number
   auto_snooze_high_minutes: number
+  auto_snooze_low_minutes: number
+  auto_snooze_medium_minutes: number
   default_snooze_option: string
   morning_time: string
   wake_time: string
@@ -456,6 +477,8 @@ const DEFAULT_PREFERENCES_ROW: PreferencesRow = {
   auto_snooze_minutes: 30,
   auto_snooze_urgent_minutes: 5,
   auto_snooze_high_minutes: 15,
+  auto_snooze_low_minutes: 240,
+  auto_snooze_medium_minutes: 60,
   default_snooze_option: '60',
   morning_time: '09:00',
   wake_time: '07:00',

--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -18,7 +18,8 @@ import { log } from '@/lib/logger'
 import { withLogging } from '@/lib/with-logging'
 import type { LabelConfig, LabelColor, PriorityDisplayConfig } from '@/types'
 
-const VALID_GROUPINGS = ['time', 'project', 'unified'] as const
+// §7.3 adds 'slot' — today grouped by time slot, the new front door.
+const VALID_GROUPINGS = ['time', 'project', 'unified', 'slot'] as const
 const VALID_SORT_OPTIONS = [
   'due_date',
   'priority',
@@ -152,7 +153,7 @@ function validateGeneralFields(
 ): string | null {
   if (body.default_grouping !== undefined) {
     if (!VALID_GROUPINGS.includes(body.default_grouping as (typeof VALID_GROUPINGS)[number]))
-      return 'default_grouping must be "time", "project", or "unified"'
+      return 'default_grouping must be "time", "project", "unified", or "slot"'
     updates.push('default_grouping = ?')
     params.push(body.default_grouping)
   }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -60,6 +60,10 @@ export default function SettingsPage() {
     setAutoSnoozeUrgent,
     autoSnoozeHigh,
     setAutoSnoozeHigh,
+    autoSnoozeLow,
+    setAutoSnoozeLow,
+    autoSnoozeMedium,
+    setAutoSnoozeMedium,
   } = useAutoSnoozeDefault()
   const { defaultSnoozeOption, setDefaultSnoozeOption, morningTime, setMorningTime } =
     useSnoozePreferences()
@@ -95,6 +99,10 @@ export default function SettingsPage() {
   const [showCustomAutoSnoozeUrgent, setShowCustomAutoSnoozeUrgent] = useState(false)
   const [customAutoSnoozeHighMinutes, setCustomAutoSnoozeHighMinutes] = useState('')
   const [showCustomAutoSnoozeHigh, setShowCustomAutoSnoozeHigh] = useState(false)
+  const [customAutoSnoozeLowMinutes, setCustomAutoSnoozeLowMinutes] = useState('')
+  const [showCustomAutoSnoozeLow, setShowCustomAutoSnoozeLow] = useState(false)
+  const [customAutoSnoozeMediumMinutes, setCustomAutoSnoozeMediumMinutes] = useState('')
+  const [showCustomAutoSnoozeMedium, setShowCustomAutoSnoozeMedium] = useState(false)
   const [testingSending, setTestingSending] = useState<string | null>(null)
   const [isNativeApp, setIsNativeApp] = useState(false)
   const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false)
@@ -198,6 +206,40 @@ export default function SettingsPage() {
       showToast({ message: 'Preference saved', type: 'success' })
     } catch {
       setAutoSnoozeUrgent(prev)
+      showToast({ message: 'Failed to save preference', type: 'error' })
+    }
+  }
+
+  const handleAutoSnoozeLowChange = async (value: number) => {
+    const prev = autoSnoozeLow
+    setAutoSnoozeLow(value)
+    try {
+      const res = await fetch('/api/user/preferences', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ auto_snooze_low_minutes: value }),
+      })
+      if (!res.ok) throw new Error('Failed to save')
+      showToast({ message: 'Preference saved', type: 'success' })
+    } catch {
+      setAutoSnoozeLow(prev)
+      showToast({ message: 'Failed to save preference', type: 'error' })
+    }
+  }
+
+  const handleAutoSnoozeMediumChange = async (value: number) => {
+    const prev = autoSnoozeMedium
+    setAutoSnoozeMedium(value)
+    try {
+      const res = await fetch('/api/user/preferences', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ auto_snooze_medium_minutes: value }),
+      })
+      if (!res.ok) throw new Error('Failed to save')
+      showToast({ message: 'Preference saved', type: 'success' })
+    } catch {
+      setAutoSnoozeMedium(prev)
       showToast({ message: 'Failed to save preference', type: 'error' })
     }
   }
@@ -641,13 +683,36 @@ export default function SettingsPage() {
             {/* Default auto-snooze */}
             <AutoSnoozeRow
               label="Default auto-snooze"
-              description="Repeat interval for other overdue tasks"
+              description="Repeat interval for unset-priority (P0) overdue tasks"
               value={autoSnoozeDefault}
               customValue={customAutoSnoozeMinutes}
               setCustomValue={setCustomAutoSnoozeMinutes}
               showCustom={showCustomAutoSnooze}
               setShowCustom={setShowCustomAutoSnooze}
               onChange={handleAutoSnoozeChange}
+            />
+            {/* §4.1: Low is rare but never silent */}
+            <AutoSnoozeRow
+              label="Low auto-snooze"
+              description="Repeat interval for low (P1) overdue tasks"
+              value={autoSnoozeLow}
+              customValue={customAutoSnoozeLowMinutes}
+              setCustomValue={setCustomAutoSnoozeLowMinutes}
+              showCustom={showCustomAutoSnoozeLow}
+              setShowCustom={setShowCustomAutoSnoozeLow}
+              onChange={handleAutoSnoozeLowChange}
+            />
+            {/* §4.1: Medium is NOT notify-once — one missed glance would lose it */}
+            <AutoSnoozeRow
+              label="Medium auto-snooze"
+              description="Repeat interval for medium (P2) overdue tasks"
+              value={autoSnoozeMedium}
+              customValue={customAutoSnoozeMediumMinutes}
+              setCustomValue={setCustomAutoSnoozeMediumMinutes}
+              showCustom={showCustomAutoSnoozeMedium}
+              setShowCustom={setShowCustomAutoSnoozeMedium}
+              onChange={handleAutoSnoozeMediumChange}
+              labelColor="text-yellow-600"
             />
             {/* High auto-snooze */}
             <AutoSnoozeRow

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -5,6 +5,9 @@ import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { TaskList, buildTaskGroups, sortTasks } from '@/components/TaskList'
 import type { GroupingMode } from '@/components/TaskList'
+import { useTimeSlots } from '@/hooks/useTimeSlots'
+import { ViewModeToggle } from '@/components/ViewModeToggle'
+import type { TimeSlot } from '@/lib/time-slot-assign'
 import type { SortOption } from '@/hooks/useGroupSort'
 import { useCollapsedGroups } from '@/hooks/useCollapsedGroups'
 import { useKeyboardNavigation } from '@/hooks/useKeyboardNavigation'
@@ -323,6 +326,7 @@ function HomeContent({ initialTasks }: { initialTasks?: FormattedTask[] }) {
   const searchParams = useSearchParams()
   const selection = useSelection()
   const timezone = useTimezone()
+  const { timeSlots } = useTimeSlots()
   const data = useFetchData(router, initialTasks)
   const { tasks, setTasks, loading, error, setError, setLoading, fetchTasks } = data
   const { projects, refreshProjects } = useProjects()
@@ -823,8 +827,8 @@ function HomeContent({ initialTasks }: { initialTasks?: FormattedTask[] }) {
 
   // Build task groups for keyboard navigation
   const taskGroups = useMemo(
-    () => buildTaskGroups(tasks_, projects, grouping, timezone),
-    [tasks_, projects, grouping, timezone],
+    () => buildTaskGroups(tasks_, projects, grouping, timezone, timeSlots),
+    [tasks_, projects, grouping, timezone, timeSlots],
   )
   // Apply per-group sorting to match the visual order in TaskList.
   // Exclude tasks in collapsed groups so keyboard navigation skips them.
@@ -1098,6 +1102,13 @@ function HomeContent({ initialTasks }: { initialTasks?: FormattedTask[] }) {
       allTasks={baseTasks}
       projects={projects}
       grouping={grouping}
+      onGroupingChange={(next) => {
+        // Selecting a view explicitly turns off AI-sort's unified override —
+        // otherwise the toggle would show a selection that isn't in effect.
+        setAiSortUnified(false)
+        setDefaultGrouping(next as 'time' | 'project' | 'unified' | 'slot')
+      }}
+      timeSlots={timeSlots}
       searchQuery={searchQuery}
       searchResultCount={searchResults.length}
       overdueCount={overdueCount}
@@ -1239,6 +1250,8 @@ function DashboardView({
   allTasks,
   projects,
   grouping,
+  onGroupingChange,
+  timeSlots,
   searchQuery,
   searchResultCount,
   overdueCount,
@@ -1347,6 +1360,9 @@ function DashboardView({
   allTasks: Task[]
   projects: Project[]
   grouping: GroupingMode
+  onGroupingChange: (grouping: GroupingMode) => void
+  /** §6.0 time slots, for `grouping === 'slot'`. Fetched once by the parent. */
+  timeSlots: TimeSlot[]
   searchQuery: string | null
   searchResultCount: number
   overdueCount: number
@@ -1549,6 +1565,11 @@ function DashboardView({
           />
         )}
 
+        {/* §7.3: the front door is "Today", but the corpus stays reachable. */}
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <ViewModeToggle grouping={grouping} onChange={onGroupingChange} />
+        </div>
+
         <FilterBar
           tasks={allTasks}
           selectedPriorities={selectedPriorities}
@@ -1628,6 +1649,7 @@ function DashboardView({
           tasks={tasks}
           projects={projects}
           grouping={grouping}
+          timeSlots={timeSlots}
           onDone={actions.handleDone}
           onSnooze={actions.handleSnooze}
           onLabelClick={onToggleLabel}

--- a/src/components/PreferencesProvider.tsx
+++ b/src/components/PreferencesProvider.tsx
@@ -39,8 +39,8 @@ interface PreferencesContextValue {
   setWakeTime: (time: string) => void
   sleepTime: string
   setSleepTime: (time: string) => void
-  defaultGrouping: 'time' | 'project' | 'unified'
-  setDefaultGrouping: (grouping: 'time' | 'project' | 'unified') => void
+  defaultGrouping: 'time' | 'project' | 'unified' | 'slot'
+  setDefaultGrouping: (grouping: 'time' | 'project' | 'unified' | 'slot') => void
   defaultSort: SortOption
   defaultSortReversed: boolean
   setSortPreference: (sort: SortOption, reversed: boolean) => void
@@ -157,9 +157,9 @@ export function PreferencesProvider({ children }: { children: React.ReactNode })
   const [morningTime, setMorningTimeState] = useState('09:00')
   const [wakeTime, setWakeTimeState] = useState('07:00')
   const [sleepTime, setSleepTimeState] = useState('22:00')
-  const [defaultGrouping, setDefaultGroupingState] = useState<'time' | 'project' | 'unified'>(
-    'project',
-  )
+  const [defaultGrouping, setDefaultGroupingState] = useState<
+    'time' | 'project' | 'unified' | 'slot'
+  >('project')
   const [defaultSort, setDefaultSortState] = useState<SortOption>('due_date')
   const [defaultSortReversed, setDefaultSortReversedState] = useState(false)
   const [notificationsEnabled, setNotificationsEnabledState] = useState(true)
@@ -378,7 +378,7 @@ export function PreferencesProvider({ children }: { children: React.ReactNode })
         sleepTime,
         setSleepTime: setSleepTimeState,
         defaultGrouping,
-        setDefaultGrouping: (grouping: 'time' | 'project' | 'unified') => {
+        setDefaultGrouping: (grouping: 'time' | 'project' | 'unified' | 'slot') => {
           setDefaultGroupingState(grouping)
           fetch('/api/user/preferences', {
             method: 'PATCH',

--- a/src/components/PreferencesProvider.tsx
+++ b/src/components/PreferencesProvider.tsx
@@ -30,7 +30,12 @@ interface PreferencesContextValue {
   autoSnoozeUrgent: number
   setAutoSnoozeUrgent: (minutes: number) => void
   autoSnoozeHigh: number
+  /** §4.1 cadence ladder — P1 and P2 get their own intervals. */
+  autoSnoozeLow: number
+  autoSnoozeMedium: number
   setAutoSnoozeHigh: (minutes: number) => void
+  setAutoSnoozeLow: (minutes: number) => void
+  setAutoSnoozeMedium: (minutes: number) => void
   defaultSnoozeOption: string
   setDefaultSnoozeOption: (option: string) => void
   morningTime: string
@@ -96,7 +101,11 @@ const PreferencesContext = createContext<PreferencesContextValue>({
   autoSnoozeUrgent: 5,
   setAutoSnoozeUrgent: () => {},
   autoSnoozeHigh: 15,
+  autoSnoozeLow: 240,
+  autoSnoozeMedium: 60,
   setAutoSnoozeHigh: () => {},
+  setAutoSnoozeLow: () => {},
+  setAutoSnoozeMedium: () => {},
   defaultSnoozeOption: '60',
   setDefaultSnoozeOption: () => {},
   morningTime: '09:00',
@@ -153,6 +162,8 @@ export function PreferencesProvider({ children }: { children: React.ReactNode })
   const [autoSnoozeDefault, setAutoSnoozeDefaultState] = useState(30)
   const [autoSnoozeUrgent, setAutoSnoozeUrgentState] = useState(5)
   const [autoSnoozeHigh, setAutoSnoozeHighState] = useState(15)
+  const [autoSnoozeLow, setAutoSnoozeLowState] = useState(240)
+  const [autoSnoozeMedium, setAutoSnoozeMediumState] = useState(60)
   const [defaultSnoozeOption, setDefaultSnoozeOptionState] = useState('60')
   const [morningTime, setMorningTimeState] = useState('09:00')
   const [wakeTime, setWakeTimeState] = useState('07:00')
@@ -255,6 +266,12 @@ export function PreferencesProvider({ children }: { children: React.ReactNode })
         }
         if (data?.data?.auto_snooze_urgent_minutes) {
           setAutoSnoozeUrgentState(data.data.auto_snooze_urgent_minutes)
+        }
+        if (data?.data?.auto_snooze_low_minutes) {
+          setAutoSnoozeLowState(data.data.auto_snooze_low_minutes)
+        }
+        if (data?.data?.auto_snooze_medium_minutes) {
+          setAutoSnoozeMediumState(data.data.auto_snooze_medium_minutes)
         }
         if (data?.data?.auto_snooze_high_minutes) {
           setAutoSnoozeHighState(data.data.auto_snooze_high_minutes)
@@ -369,6 +386,10 @@ export function PreferencesProvider({ children }: { children: React.ReactNode })
         setAutoSnoozeUrgent: setAutoSnoozeUrgentState,
         autoSnoozeHigh,
         setAutoSnoozeHigh: setAutoSnoozeHighState,
+        autoSnoozeLow,
+        setAutoSnoozeLow: setAutoSnoozeLowState,
+        autoSnoozeMedium,
+        setAutoSnoozeMedium: setAutoSnoozeMediumState,
         defaultSnoozeOption,
         setDefaultSnoozeOption: setDefaultSnoozeOptionState,
         morningTime,
@@ -454,6 +475,10 @@ export function useAutoSnoozeDefault() {
     setAutoSnoozeUrgent,
     autoSnoozeHigh,
     setAutoSnoozeHigh,
+    autoSnoozeLow,
+    setAutoSnoozeLow,
+    autoSnoozeMedium,
+    setAutoSnoozeMedium,
   } = useContext(PreferencesContext)
   return {
     autoSnoozeDefault,
@@ -462,6 +487,10 @@ export function useAutoSnoozeDefault() {
     setAutoSnoozeUrgent,
     autoSnoozeHigh,
     setAutoSnoozeHigh,
+    autoSnoozeLow,
+    setAutoSnoozeLow,
+    autoSnoozeMedium,
+    setAutoSnoozeMedium,
   }
 }
 

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -22,10 +22,33 @@ import { useTimezone } from '@/hooks/useTimezone'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useSnoozePreferences } from '@/components/PreferencesProvider'
 import { computeSnoozeTime } from '@/lib/snooze'
+import { groupBySlot, type TimeSlot } from '@/lib/time-slot-assign'
+import { effectiveDueAt } from '@/core/recurrence/occurrence'
+import { DateTime } from 'luxon'
+
+/**
+ * §7.3: items with no time of day (most Track items) get their own group after
+ * the timed slots rather than being dropped from the front door.
+ */
+const UNSLOTTED_LABEL = 'Anytime today'
+
+/**
+ * How many tasks a group shows before "show all" (§7.3).
+ *
+ * The point is that the view scales to ANY group size without truncating
+ * content — §1.1's founding constraint is that the harness adapts to the scale,
+ * so nothing is ever hidden permanently, just collapsed behind one tap.
+ */
+const GROUP_PREVIEW_COUNT = 5
 import { useSnoozeGuard } from '@/hooks/useSnoozeGuard'
 import { SnoozeGuardDialog } from '@/components/SnoozeGuardDialog'
 
-export type GroupingMode = 'time' | 'project' | 'unified'
+/**
+ * `slot` is the §7.3 front door: today's tasks grouped by time slot. The other
+ * modes remain reachable — the corpus stays fully accessible, it just isn't
+ * what greets you.
+ */
+export type GroupingMode = 'time' | 'project' | 'unified' | 'slot'
 
 import { useSelectionOptional, type SelectionContextType } from './SelectionProvider'
 
@@ -46,6 +69,8 @@ interface TaskListProps {
   tasks: Task[]
   projects?: Project[]
   grouping?: GroupingMode
+  /** Time slots for `grouping === 'slot'` (§6.0). */
+  timeSlots?: TimeSlot[]
   onDone: (taskId: number) => void
   /** Called with (taskId, until) for immediate snooze (single-click, swipe, or menu) */
   onSnooze: (taskId: number, until: string) => void
@@ -204,6 +229,7 @@ export function TaskList({
   tasks,
   projects = [],
   grouping = 'time',
+  timeSlots = [],
   onDone,
   onSnooze,
   onLabelClick,
@@ -266,6 +292,19 @@ export function TaskList({
   // which must never modal-block.
   const { requestSnooze, dialogProps } = useSnoozeGuard(timezone, onSnooze)
 
+  // Which slot groups have been expanded past their preview (§7.3). Local
+  // state, not persisted: expansion is a momentary "show me the rest", not a
+  // preference worth remembering across sessions.
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
+  const toggleGroupExpanded = useCallback((label: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev)
+      if (next.has(label)) next.delete(label)
+      else next.add(label)
+      return next
+    })
+  }, [])
+
   const handleSwipeLeft = useCallback(
     (task: Task) => {
       if (isTaskOverdue(task)) {
@@ -283,7 +322,13 @@ export function TaskList({
       <div className="flex flex-col items-center justify-center py-16 text-center">
         <div className="mb-4 text-4xl">&#x2705;</div>
         <h2 className="text-foreground text-xl font-medium">All caught up!</h2>
-        <p className="text-muted-foreground mt-1">No tasks due right now.</p>
+        <p className="text-muted-foreground mt-1">
+          {grouping === 'slot'
+            ? // §7.3 explicitly wants the inbox-zero feeling for TODAY, while
+              // being honest that later-today items still pend.
+              'Nothing left for today.'
+            : 'No tasks due right now.'}
+        </p>
       </div>
     )
   }
@@ -298,7 +343,9 @@ export function TaskList({
     ? [{ label: '_unified', tasks }]
     : grouping === 'project'
       ? groupByProject(tasks, projects)
-      : groupByTime(tasks, timezone)
+      : grouping === 'slot'
+        ? groupByTimeSlot(tasks, timeSlots, timezone)
+        : groupByTime(tasks, timezone)
 
   // Compute sorted groups once, reuse for both orderedIds and rendering
   const sortedGroups = groups.map((g) => ({
@@ -361,6 +408,17 @@ export function TaskList({
           const { sortedTasks } = group
           const collapsed = !isUnified && isCollapsed(group.label)
 
+          // §7.3: show the first N, with everything else one tap away. Nothing
+          // is ever truncated permanently — §1.1's constraint is that the
+          // harness adapts to the scale, so a 40-item slot stays fully
+          // reachable while the day still reads at a glance. Only applies to
+          // slot grouping; the other views keep their existing behaviour.
+          const previewed = grouping === 'slot' && !isUnified
+          const isExpanded = expandedGroups.has(group.label)
+          const visibleTasks =
+            previewed && !isExpanded ? sortedTasks.slice(0, GROUP_PREVIEW_COUNT) : sortedTasks
+          const hiddenCount = sortedTasks.length - visibleTasks.length
+
           return (
             <section key={group.label}>
               {/* "Now" separator between Overdue and the next group */}
@@ -421,7 +479,7 @@ export function TaskList({
               )}
               {!collapsed && (
                 <div className="space-y-1">
-                  {sortedTasks.map((task) => {
+                  {visibleTasks.map((task) => {
                     const cancelRef = { current: null as (() => void) | null }
                     return (
                       <SwipeableRow
@@ -464,6 +522,25 @@ export function TaskList({
                       </SwipeableRow>
                     )
                   })}
+                  {hiddenCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => toggleGroupExpanded(group.label)}
+                      className="text-muted-foreground hover:text-foreground w-full rounded-lg py-2 text-xs font-medium transition-colors"
+                    >
+                      Show all {sortedTasks.length}
+                      <span className="text-muted-foreground/60"> ({hiddenCount} more)</span>
+                    </button>
+                  )}
+                  {isExpanded && sortedTasks.length > GROUP_PREVIEW_COUNT && (
+                    <button
+                      type="button"
+                      onClick={() => toggleGroupExpanded(group.label)}
+                      className="text-muted-foreground hover:text-foreground w-full rounded-lg py-2 text-xs font-medium transition-colors"
+                    >
+                      Show less
+                    </button>
+                  )}
                 </div>
               )}
             </section>
@@ -534,6 +611,59 @@ function groupByTime(tasks: Task[], timezone: string): TaskGroup[] {
   }
 
   return groups
+}
+
+/**
+ * Group today's tasks into time slots (§7.3).
+ *
+ * Two things this must not do:
+ *
+ * 1. Drop the un-slotted items. Anything with no time of day — which is most
+ *    Track items — goes into an explicit "Anytime today" group rendered AFTER
+ *    the timed slots. §7.3 is explicit that they must not become invisible
+ *    from the front door.
+ * 2. Hide empty slots... except when the whole day is empty. A slot the user
+ *    defined is part of how they read their day, so an empty "Midday" still
+ *    renders as a container. But rendering five empty containers when there is
+ *    genuinely nothing left defeats the "all caught up" feeling §7.3 asks for,
+ *    so a fully-empty day collapses to no groups and the caught-up state shows.
+ */
+function groupByTimeSlot(tasks: Task[], slots: TimeSlot[], timezone: string): TaskGroup[] {
+  if (tasks.length === 0) return []
+
+  // §7.3: the front door is TODAY, not the whole corpus. Due-ness comes from
+  // §4.6's derivation rather than raw due_at, so a recurring item whose date
+  // froze months ago doesn't wrongly appear, and one that genuinely recurs
+  // today does — even if its stored due_at disagrees.
+  //
+  // Undated items are kept: they can't be "not today", and dropping them would
+  // hide most Track items from the front door, which §7.3 forbids.
+  const now = new Date()
+  const endOfToday = DateTime.fromJSDate(now).setZone(timezone).endOf('day').toJSDate()
+
+  const todays = tasks.filter((task) => {
+    if (!task.due_at && !task.rrule) return true
+    const effective = effectiveDueAt(task, timezone, now)
+    if (!effective) return false
+    return effective.getTime() <= endOfToday.getTime()
+  })
+
+  if (todays.length === 0) return []
+
+  const grouped = groupBySlot(todays, slots, timezone)
+  const out: TaskGroup[] = []
+
+  for (const group of grouped) {
+    if (group.slot === null) {
+      if (group.items.length > 0) {
+        out.push({ label: UNSLOTTED_LABEL, tasks: group.items })
+      }
+      continue
+    }
+    out.push({ label: group.slot.label, tasks: group.items })
+  }
+
+  return out
 }
 
 function groupByProject(tasks: Task[], projects: Project[]): TaskGroup[] {
@@ -727,7 +857,10 @@ export function buildTaskGroups(
   projects: Project[],
   grouping: GroupingMode,
   timezone: string,
+  timeSlots: TimeSlot[] = [],
 ): TaskGroup[] {
   if (grouping === 'unified') return [{ label: '_unified', tasks }]
-  return grouping === 'project' ? groupByProject(tasks, projects) : groupByTime(tasks, timezone)
+  if (grouping === 'project') return groupByProject(tasks, projects)
+  if (grouping === 'slot') return groupByTimeSlot(tasks, timeSlots, timezone)
+  return groupByTime(tasks, timezone)
 }

--- a/src/components/ViewModeToggle.tsx
+++ b/src/components/ViewModeToggle.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { CalendarClock, FolderTree, List } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { GroupingMode } from '@/components/TaskList'
+
+interface ViewModeToggleProps {
+  grouping: GroupingMode
+  onChange: (grouping: GroupingMode) => void
+}
+
+/**
+ * Switches how the task list is grouped (REDESIGN-V03 §7.3).
+ *
+ * "Today" is the front door: today's work grouped by time slot, so opening the
+ * app answers "what now" without scanning. The other two exist because §7.3 is
+ * equally explicit that the corpus stays fully accessible — it just isn't what
+ * greets you. Without a visible control the old views would be unreachable,
+ * which would trade one kind of stuck for another.
+ *
+ * Deliberately three options, not a dropdown of every permutation: the point of
+ * the redesign is fewer decisions at the front door, and a picker with six
+ * entries would just be the 20-filter-chip problem in miniature.
+ */
+export function ViewModeToggle({ grouping, onChange }: ViewModeToggleProps) {
+  // 'unified' is driven by the AI-sort toggle elsewhere; showing it here as a
+  // fourth option would let the two controls disagree about what's active.
+  const options: { value: GroupingMode; label: string; icon: typeof List; hint: string }[] = [
+    { value: 'slot', label: 'Today', icon: CalendarClock, hint: "Today's tasks by time of day" },
+    { value: 'project', label: 'Projects', icon: FolderTree, hint: 'Group by project' },
+    { value: 'time', label: 'All', icon: List, hint: 'Everything by due date' },
+  ]
+
+  return (
+    <div
+      role="group"
+      aria-label="View mode"
+      className="bg-muted/50 inline-flex items-center gap-0.5 rounded-lg p-0.5"
+    >
+      {options.map((option) => {
+        const Icon = option.icon
+        const active = grouping === option.value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            aria-pressed={active}
+            title={option.hint}
+            className={cn(
+              'flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+              active
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <Icon className="size-3.5" />
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/core/db/index.ts
+++ b/src/core/db/index.ts
@@ -199,6 +199,10 @@ function runMigrations(database: Database.Database): void {
   if (!hasColumn(database, 'tasks', 'skip_count')) {
     database.exec('ALTER TABLE tasks ADD COLUMN skip_count INTEGER NOT NULL DEFAULT 0')
   }
+  // Reminders surface (§6)
+  if (!hasColumn(database, 'tasks', 'is_reminder')) {
+    database.exec('ALTER TABLE tasks ADD COLUMN is_reminder INTEGER NOT NULL DEFAULT 0')
+  }
 
   backfillLabelRegistry(database)
   backfillTimeSlots(database)

--- a/src/core/db/index.ts
+++ b/src/core/db/index.ts
@@ -199,6 +199,18 @@ function runMigrations(database: Database.Database): void {
   if (!hasColumn(database, 'tasks', 'skip_count')) {
     database.exec('ALTER TABLE tasks ADD COLUMN skip_count INTEGER NOT NULL DEFAULT 0')
   }
+  // §4.1 cadence ladder: P1 and P2 get their own intervals
+  if (!hasColumn(database, 'users', 'auto_snooze_low_minutes')) {
+    database.exec(
+      'ALTER TABLE users ADD COLUMN auto_snooze_low_minutes INTEGER NOT NULL DEFAULT 240',
+    )
+  }
+  if (!hasColumn(database, 'users', 'auto_snooze_medium_minutes')) {
+    database.exec(
+      'ALTER TABLE users ADD COLUMN auto_snooze_medium_minutes INTEGER NOT NULL DEFAULT 60',
+    )
+  }
+
   // Reminders surface (§6)
   if (!hasColumn(database, 'tasks', 'is_reminder')) {
     database.exec('ALTER TABLE tasks ADD COLUMN is_reminder INTEGER NOT NULL DEFAULT 0')

--- a/src/core/db/schema.sql
+++ b/src/core/db/schema.sql
@@ -20,6 +20,15 @@ CREATE TABLE IF NOT EXISTS users (
   auto_snooze_minutes INTEGER NOT NULL DEFAULT 30,
   auto_snooze_urgent_minutes INTEGER NOT NULL DEFAULT 5,
   auto_snooze_high_minutes INTEGER NOT NULL DEFAULT 15,
+  -- §4.1: the cadence ladder. auto_snooze_minutes above is now P0-ONLY.
+  -- P1 is rare-but-present rather than silent, and P2 is NOT notify-once:
+  -- one missed glance (phone face-down, in a meeting) would lose it
+  -- permanently, which fails dangerous for something rated moderately
+  -- important. Nothing goes fully silent by default (L2) — the bottom rungs
+  -- get slower cadence plus replacement (§4.2), so persistence never becomes
+  -- pile-up.
+  auto_snooze_low_minutes INTEGER NOT NULL DEFAULT 240,
+  auto_snooze_medium_minutes INTEGER NOT NULL DEFAULT 60,
   default_snooze_option TEXT NOT NULL DEFAULT '60',
   morning_time  TEXT NOT NULL DEFAULT '09:00',
   wake_time     TEXT NOT NULL DEFAULT '07:00',

--- a/src/core/db/schema.sql
+++ b/src/core/db/schema.sql
@@ -100,6 +100,12 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- §7.5: occurrences declined without recording a completion, so
   -- completion_count stays honest.
   skip_count       INTEGER NOT NULL DEFAULT 0,
+  -- Reminders surface (REDESIGN-V03 §6). A boolean column, deliberately NOT a
+  -- label: §7.1 rules that kind is never stored as a name, and a
+  -- behavior-bearing value inside the JSON labels array would need json_each()
+  -- at every query site that wants an indexed boolean (overdue-checker,
+  -- dashboard, badge).
+  is_reminder      INTEGER NOT NULL DEFAULT 0,
 
   -- Notification tracking
   last_notified_at TEXT,            -- Vestigial (replaced by mod-based boundary detection); kept for existing DB compat

--- a/src/core/notifications/apns.ts
+++ b/src/core/notifications/apns.ts
@@ -130,6 +130,31 @@ export interface ApnsPushPayload {
 }
 
 /**
+ * Per-class notification threads (REDESIGN-V03 §4.2).
+ *
+ * A single thread ID meant every notification piled into one visible stack, so
+ * an urgent item and a routine one were indistinguishable at a glance. Separate
+ * threads make iOS group them as separate stacks.
+ *
+ * Splitting urgent from ordinary tasks is the point: the whole redesign is
+ * about the interruption surface staying constant as volume grows, and a
+ * stack you can triage by looking at it is the visual half of that.
+ */
+export const NOTIFICATION_THREADS = {
+  /** §6 Reminders — the time slot notifies, not the item. */
+  reminders: 'ot-reminders',
+  /** Ordinary overdue tasks (P0–P3). */
+  tasks: 'ot-tasks',
+  /** P4 — breaks through everything, so it gets its own stack. */
+  urgent: 'ot-urgent',
+} as const
+
+/** Which thread a task notification belongs to, by priority. */
+export function threadIdForPriority(priority: number): string {
+  return priority >= 4 ? NOTIFICATION_THREADS.urgent : NOTIFICATION_THREADS.tasks
+}
+
+/**
  * Send a push notification to all APNs devices for a user.
  * Cleans up stale device tokens automatically.
  */
@@ -146,7 +171,9 @@ export async function sendApnsNotification(
         alert: { title: payload.title, body: payload.body },
         topic: device.bundle_id,
         category: 'TASK_REMINDER',
-        threadId: 'opentask-overdue',
+        // §4.2: urgent gets its own visible stack so it can't be lost among
+        // routine items.
+        threadId: threadIdForPriority(payload.priority),
         badge: payload.badge,
         sound: isCritical
           ? { critical: 1, name: 'default', volume: payload.criticalAlertVolume ?? 1.0 }
@@ -194,7 +221,7 @@ export async function sendApnsSummaryNotification(
         alert: { title, body },
         topic: device.bundle_id,
         category: 'TASK_SUMMARY',
-        threadId: 'opentask-overdue',
+        threadId: NOTIFICATION_THREADS.tasks,
         sound: 'default',
         collapseId: 'overdue-summary',
         data: {

--- a/src/core/notifications/overdue-checker.ts
+++ b/src/core/notifications/overdue-checker.ts
@@ -265,6 +265,8 @@ export async function checkOverdueTasks(nowOverride?: Date): Promise<void> {
           -- §5: tracked items are exempt from the cadence loop (see
           -- currently-due.ts for the rationale).
           AND t.progress_target <= 1
+          -- §6: reminders never fire individually — their time slot notifies.
+          AND t.is_reminder = 0
           AND (
             t.rrule IS NOT NULL
             OR (t.due_at IS NOT NULL AND datetime(t.due_at) <= datetime(?))

--- a/src/core/notifications/overdue-checker.ts
+++ b/src/core/notifications/overdue-checker.ts
@@ -53,6 +53,8 @@ interface OverdueTask {
   user_auto_snooze_minutes: number
   user_auto_snooze_urgent_minutes: number
   user_auto_snooze_high_minutes: number
+  user_auto_snooze_low_minutes: number
+  user_auto_snooze_medium_minutes: number
   critical_alert_volume: number
   // §4.6 inputs — a recurring task's due-today-ness comes from its schedule,
   // not from due_at, which freezes as soon as the daily sweep stops.
@@ -79,11 +81,28 @@ interface NotificationBucket {
 /**
  * Get the effective notification repeat interval for a task in minutes.
  * Per-task override > priority-based user default.
+ *
+ * §4.1 cadence ladder. Every rung branches EXPLICITLY — previously P0, P1 and
+ * P2 all fell through to one shared value, which is why priority behaved as a
+ * binary "matters" flag rather than a ladder.
+ *
+ *   P0 unset  → 30 min   (unchanged; L2 failure-safe — an urgent-but-
+ *                         unclassified item must still reach the user)
+ *   P1 low    → 240 min  (rare, but never silent)
+ *   P2 medium → 60 min   (NOT notify-once: one missed glance would lose it
+ *                         permanently, which fails dangerous)
+ *   P3 high   → 15 min   (unchanged)
+ *   P4 urgent → 5 min    (unchanged)
+ *
+ * P0 keeps its own column rather than sharing with P1: unset means nobody
+ * stated a priority (L1), not "lowest", so the two must be tunable apart.
  */
 function getEffectiveInterval(task: OverdueTask): number {
   if (task.auto_snooze_minutes !== null) return task.auto_snooze_minutes
-  if (task.priority >= 4) return task.user_auto_snooze_urgent_minutes
+  if (task.priority >= URGENT_PRIORITY) return task.user_auto_snooze_urgent_minutes
   if (task.priority >= HIGH_PRIORITY_THRESHOLD) return task.user_auto_snooze_high_minutes
+  if (task.priority === 2) return task.user_auto_snooze_medium_minutes
+  if (task.priority === 1) return task.user_auto_snooze_low_minutes
   return task.user_auto_snooze_minutes
 }
 
@@ -255,6 +274,8 @@ export async function checkOverdueTasks(nowOverride?: Date): Promise<void> {
                u.auto_snooze_minutes as user_auto_snooze_minutes,
                u.auto_snooze_urgent_minutes as user_auto_snooze_urgent_minutes,
                u.auto_snooze_high_minutes as user_auto_snooze_high_minutes,
+               u.auto_snooze_low_minutes as user_auto_snooze_low_minutes,
+               u.auto_snooze_medium_minutes as user_auto_snooze_medium_minutes,
                u.critical_alert_volume
         FROM tasks t
         INNER JOIN users u ON t.user_id = u.id

--- a/src/core/tasks/bulk.ts
+++ b/src/core/tasks/bulk.ts
@@ -186,6 +186,7 @@ export function bulkDone(options: BulkDoneOptions): BulkDoneResult {
 interface BulkSnoozeFilterResult {
   eligible: Task[]
   urgentSkipped: number
+  reminderSkipped: number
 }
 
 /**
@@ -199,11 +200,22 @@ interface BulkSnoozeFilterResult {
  * kept for API compatibility (`skipped_urgent` reaches the iOS client).
  */
 function filterForBulkSnooze(tasks: Task[], includeTaskIds?: Set<number>): BulkSnoozeFilterResult {
-  const eligible = tasks.filter(
+  // §6: reminders are bucket-locked and can never be snoozed, not even by an
+  // explicit selection — `include_task_ids` deliberately does NOT rescue them,
+  // because the constraint is about what a reminder IS, not about how carefully
+  // the user picked it.
+  //
+  // Skipped silently and reported as a count, never prompted: §4.3 is explicit
+  // that bulk paths must not modal-block, and per L1 sweep participation
+  // carries no per-item intent to confirm.
+  const snoozable = tasks.filter((t) => !t.is_reminder)
+  const reminderSkipped = tasks.length - snoozable.length
+
+  const eligible = snoozable.filter(
     (t) => (t.priority ?? 0) < HIGH_PRIORITY_THRESHOLD || includeTaskIds?.has(t.id),
   )
-  const urgentSkipped = tasks.length - eligible.length
-  return { eligible, urgentSkipped }
+  const urgentSkipped = snoozable.length - eligible.length
+  return { eligible, urgentSkipped, reminderSkipped }
 }
 
 export interface BulkSnoozeOptions {
@@ -222,6 +234,8 @@ export interface BulkSnoozeResult {
   tasksAffected: number
   tasksSkipped: number
   urgentSkipped: number
+  /** §6: reminders excluded because they are bucket-locked. */
+  reminderSkipped: number
   noDueDateSkipped: number
 }
 
@@ -238,7 +252,13 @@ export function bulkSnooze(options: BulkSnoozeOptions): BulkSnoozeResult {
   const { userId, userTimezone, taskIds, until, deltaMinutes, includeTaskIds } = options
 
   if (taskIds.length === 0) {
-    return { tasksAffected: 0, tasksSkipped: 0, urgentSkipped: 0, noDueDateSkipped: 0 }
+    return {
+      tasksAffected: 0,
+      tasksSkipped: 0,
+      urgentSkipped: 0,
+      reminderSkipped: 0,
+      noDueDateSkipped: 0,
+    }
   }
 
   // Validate that exactly one mode is specified
@@ -264,7 +284,7 @@ export function bulkSnooze(options: BulkSnoozeOptions): BulkSnoozeResult {
 
   // P0-P2 eligible, P3/P4 (High/Urgent) excluded — unless explicitly included
   const includeSet = includeTaskIds?.length ? new Set(includeTaskIds) : undefined
-  const { eligible, urgentSkipped } = filterForBulkSnooze(tasks, includeSet)
+  const { eligible, urgentSkipped, reminderSkipped } = filterForBulkSnooze(tasks, includeSet)
 
   // In relative mode, skip tasks without a due_at (can't add delta to nothing)
   let noDueDateSkipped = 0
@@ -281,7 +301,13 @@ export function bulkSnooze(options: BulkSnoozeOptions): BulkSnoozeResult {
 
   const skippedCount = tasks.length - snoozeable.length
   if (snoozeable.length === 0) {
-    return { tasksAffected: 0, tasksSkipped: skippedCount, urgentSkipped, noDueDateSkipped }
+    return {
+      tasksAffected: 0,
+      tasksSkipped: skippedCount,
+      urgentSkipped,
+      reminderSkipped,
+      noDueDateSkipped,
+    }
   }
 
   const snapshots: UndoSnapshot[] = []
@@ -369,6 +395,7 @@ export function bulkSnooze(options: BulkSnoozeOptions): BulkSnoozeResult {
       tasksAffected: snoozeable.length,
       tasksSkipped: skippedCount,
       urgentSkipped,
+      reminderSkipped,
       noDueDateSkipped,
     }
   })

--- a/src/core/tasks/create.ts
+++ b/src/core/tasks/create.ts
@@ -111,8 +111,8 @@ export function createTask(options: CreateTaskOptions): Task {
       INSERT INTO tasks (
         user_id, project_id, title, original_title, done, priority, due_at, original_due_at,
         rrule, recurrence_mode, anchor_time, anchor_dow, anchor_dom,
-        auto_snooze_minutes, labels, notes, progress_target, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        auto_snooze_minutes, labels, notes, progress_target, is_reminder, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       )
       .run(
@@ -133,6 +133,7 @@ export function createTask(options: CreateTaskOptions): Task {
         input.notes ?? null,
         // §5: setting a target above 1 at creation is the whole opt-in gesture.
         input.progress_target ?? 1,
+        input.is_reminder ? 1 : 0,
         now,
         now,
       )
@@ -191,7 +192,7 @@ export function getTaskById(taskId: number): Task | null {
            rrule, recurrence_mode, anchor_time, anchor_dow, anchor_dom,
            original_due_at, last_notified_at, last_critical_alert_at, auto_snooze_minutes,
            deleted_at, archived_at, labels,
-           progress_target, progress_current,
+           progress_target, progress_current, is_reminder,
            completion_count, snooze_count, skip_count, first_completed_at, last_completed_at,
            notes, created_at, updated_at
     FROM tasks WHERE id = ?
@@ -309,7 +310,7 @@ export function getTasks(options: GetTasksOptions): Task[] {
            tasks.anchor_dow, tasks.anchor_dom, tasks.original_due_at,
            tasks.last_notified_at, tasks.last_critical_alert_at, tasks.auto_snooze_minutes,
            tasks.deleted_at, tasks.archived_at,
-           tasks.labels, tasks.progress_target, tasks.progress_current,
+           tasks.labels, tasks.progress_target, tasks.progress_current, tasks.is_reminder,
            tasks.completion_count, tasks.snooze_count, tasks.skip_count,
            tasks.first_completed_at, tasks.last_completed_at,
            tasks.notes, tasks.created_at, tasks.updated_at
@@ -349,6 +350,7 @@ interface TaskRow {
   labels: string
   progress_target: number
   progress_current: number
+  is_reminder: number
   completion_count: number
   snooze_count: number
   skip_count: number
@@ -387,6 +389,7 @@ function rowToTask(row: TaskRow): Task {
     // produce NaN in pace math.
     progress_target: row.progress_target ?? 1,
     progress_current: row.progress_current ?? 0,
+    is_reminder: (row.is_reminder ?? 0) === 1,
     completion_count: row.completion_count,
     snooze_count: row.snooze_count,
     skip_count: row.skip_count ?? 0,

--- a/src/core/tasks/currently-due.ts
+++ b/src/core/tasks/currently-due.ts
@@ -47,6 +47,11 @@ function fetchDueCandidates(userId: number): DueCandidate[] {
           -- tracked task with a due date would get the standard nag PLUS the
           -- nudge, which is the pile-up this redesign exists to remove.
           AND t.progress_target <= 1
+          -- §6: reminders have NO DEBT. They are never counted in overdue,
+          -- never reach the badge, and never fire individually — the time slot
+          -- notifies, not the item. Missing one costs nothing; the next
+          -- occurrence simply arrives.
+          AND t.is_reminder = 0
           AND (
             t.rrule IS NOT NULL
             OR (t.due_at IS NOT NULL AND datetime(t.due_at) < datetime('now'))

--- a/src/core/tasks/helpers/collect-field-changes.ts
+++ b/src/core/tasks/helpers/collect-field-changes.ts
@@ -46,9 +46,16 @@ function trackField<K extends keyof Task>(
   oldVal: Task[K],
   newVal: Task[K],
   clause: string = `${field} = ?`,
+  /**
+   * What to bind for this column, when it differs from the domain value.
+   * SQLite has no boolean type and better-sqlite3 refuses to bind one, so
+   * boolean fields keep their JS type in the undo snapshot (where readers
+   * expect a boolean) while binding 0/1 here.
+   */
+  dbValue: unknown = newVal,
 ): void {
   data.setClauses.push(clause)
-  data.values.push(newVal)
+  data.values.push(dbValue)
   data.fieldsChanged.push(field)
   data.beforeState[field] = oldVal
   data.afterState[field] = newVal
@@ -203,6 +210,19 @@ function collectBasicFields(
 
   if (input.progress_current !== undefined && input.progress_current !== task.progress_current) {
     trackField(data, 'progress_current', task.progress_current, input.progress_current)
+  }
+
+  // §6: moving an item onto (or off) the Reminders surface. Stored as 0/1 —
+  // the DB column is an integer, and writing a JS boolean would bind as such.
+  if (input.is_reminder !== undefined && input.is_reminder !== task.is_reminder) {
+    trackField(
+      data,
+      'is_reminder',
+      task.is_reminder,
+      input.is_reminder,
+      'is_reminder = ?',
+      input.is_reminder ? 1 : 0,
+    )
   }
 }
 

--- a/src/core/tasks/reminders.ts
+++ b/src/core/tasks/reminders.ts
@@ -1,0 +1,92 @@
+/**
+ * Reminders surface queries (REDESIGN-V03 §6)
+ *
+ * Prompted thoughts — principles and considerations delivered by repetition
+ * ("Depressed = Past, Anxious = Future, Present = Peace"). Not actions.
+ * Completing one means "I considered it", and that IS its completion.
+ *
+ * These differ BEHAVIOURALLY from tasks, which is why they get a surface rather
+ * than a tag: no debt, no badge, bucket-locked, container-notified. Behaviour
+ * enforced by the surface beats behaviour promised by discipline.
+ *
+ * WHAT MAKES A REMINDER "CURRENT TODAY": exactly the §4.6 schedule derivation,
+ * not `due_at` freshness. A missed reminder therefore resets naturally at its
+ * next occurrence — there is no roll-forward job and no accumulated
+ * "overdue by N days" state, ever. That absence of debt is the whole point.
+ */
+
+import { getDb } from '@/core/db'
+import { todaysOccurrence } from '@/core/recurrence/occurrence'
+import { groupBySlot, listTimeSlots, type TimeSlot } from '@/core/time-slots'
+import type { Task } from '@/types'
+import { getTasks } from './create'
+
+export interface ReminderGroup {
+  slot: TimeSlot | null
+  reminders: Task[]
+}
+
+/**
+ * Every reminder for a user that is scheduled for today and not yet done.
+ *
+ * "Only incomplete items" is deliberate (§6): a completed reminder drops out of
+ * its bucket rather than sitting there greyed out, because leaving it would
+ * bury the ones still worth considering.
+ */
+export function getTodaysReminders(
+  userId: number,
+  timezone: string,
+  now: Date = new Date(),
+): Task[] {
+  const all = getTasks({ userId, done: false, limit: 1000 }).filter((t) => t.is_reminder)
+
+  return all.filter((task) => {
+    // Non-recurring reminders show whenever they're undone — they have no
+    // schedule to fall outside of.
+    if (!task.rrule) return true
+    return todaysOccurrence(task, timezone, now) !== null
+  })
+}
+
+/**
+ * Today's reminders grouped into their time slots.
+ *
+ * Within a slot, higher priority sorts first — §6's "priority is prominence,
+ * not interruption". The canonical high-priority reminder (morning
+ * supplements: "you don't have to, but consistency matters") is important
+ * without being an interrupt, so importance is expressed by position and
+ * weight rather than by nagging.
+ */
+export function getRemindersBySlot(
+  userId: number,
+  timezone: string,
+  now: Date = new Date(),
+): ReminderGroup[] {
+  const reminders = getTodaysReminders(userId, timezone, now)
+  const slots = listTimeSlots(userId)
+
+  return groupBySlot(reminders, slots, timezone).map((group) => ({
+    slot: group.slot,
+    reminders: [...group.items].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0)),
+  }))
+}
+
+/** How many reminders are pending in each slot — used by the slot notifications (§4.2). */
+export function countRemindersBySlot(
+  userId: number,
+  timezone: string,
+  now: Date = new Date(),
+): { slot: TimeSlot | null; count: number }[] {
+  return getRemindersBySlot(userId, timezone, now).map((g) => ({
+    slot: g.slot,
+    count: g.reminders.length,
+  }))
+}
+
+/** Is this task on the Reminders surface? Cheap check without loading the row. */
+export function isReminderTask(taskId: number): boolean {
+  const row = getDb().prepare('SELECT is_reminder FROM tasks WHERE id = ?').get(taskId) as
+    | { is_reminder: number }
+    | undefined
+  return row?.is_reminder === 1
+}

--- a/src/core/tasks/snooze.ts
+++ b/src/core/tasks/snooze.ts
@@ -55,6 +55,17 @@ export function snoozeTask(options: SnoozeTaskOptions): SnoozeResult {
   // Note: We allow snoozing to past times - the task will just appear overdue immediately.
   // This lets users adjust due dates freely using the increment/decrement controls.
 
+  // §6: reminders cannot be snoozed out of their time slot. They stay visible
+  // in the slot until completed — completion means "considered", which is the
+  // whole interaction. Allowing a snooze would reintroduce exactly the
+  // defensive re-dating this redesign removes, on the one population that has
+  // no debt to defer.
+  if (task.is_reminder) {
+    throw new ValidationError(
+      'Reminders cannot be snoozed — they stay in their time slot until completed',
+    )
+  }
+
   // Only active tasks can be snoozed (SN-005)
   if (task.done) {
     throw new ValidationError('Cannot snooze done task')

--- a/src/core/time-slots/index.ts
+++ b/src/core/time-slots/index.ts
@@ -18,34 +18,23 @@
 
 import { getDb } from '@/core/db'
 import { ValidationError } from '@/core/errors'
-import { utcToLocal } from '@/core/recurrence'
 
-export interface TimeSlot {
-  id: number
-  user_id: number
-  label: string
-  /** HH:MM local */
-  start_time: string
-  sort_order: number
-  created_at: string
-}
+/**
+ * The pure assignment logic lives in `@/lib/time-slot-assign` so the dashboard
+ * can group by slot client-side without dragging better-sqlite3 into the
+ * browser bundle. Re-exported here so server callers have one import.
+ */
+export {
+  parseHHMM,
+  itemTimeOfDayMinutes,
+  assignSlot,
+  groupBySlot,
+  DEFAULT_TIME_SLOTS,
+  type TimeSlot,
+  type SlottableItem,
+} from '@/lib/time-slot-assign'
 
-/** Seeded from the production clusters measured at spec time (§6.0). */
-export const DEFAULT_TIME_SLOTS: ReadonlyArray<{ label: string; start_time: string }> = [
-  { label: 'Early morning', start_time: '07:00' },
-  { label: 'Before work', start_time: '09:00' },
-  { label: 'Midday', start_time: '12:00' },
-  { label: 'Afternoon', start_time: '16:00' },
-  { label: 'Evening', start_time: '20:30' },
-]
-
-const HHMM = /^([01]\d|2[0-3]):([0-5]\d)$/
-
-export function parseHHMM(value: string): number | null {
-  const match = HHMM.exec(value)
-  if (!match) return null
-  return parseInt(match[1], 10) * 60 + parseInt(match[2], 10)
-}
+import { DEFAULT_TIME_SLOTS, parseHHMM, type TimeSlot } from '@/lib/time-slot-assign'
 
 export function listTimeSlots(userId: number): TimeSlot[] {
   return getDb()
@@ -96,96 +85,4 @@ export function deleteTimeSlot(userId: number, slotId: number): boolean {
     getDb().prepare('DELETE FROM time_slots WHERE user_id = ? AND id = ?').run(userId, slotId)
       .changes > 0
   )
-}
-
-/**
- * The item shape slot assignment needs.
- *
- * `anchor_time` wins over `due_at` because for a recurring item it is the
- * *intended* time of day, and §4.6 establishes that a recurring item's `due_at`
- * cannot be trusted — it only stays fresh while the user keeps sweeping.
- */
-export interface SlottableItem {
-  anchor_time: string | null
-  due_at: string | null
-}
-
-/**
- * Resolve an item's local time of day in minutes, or null if it has none.
- *
- * `anchor_time` is already local HH:MM. `due_at` is UTC and must be converted
- * through the user's timezone — reading its UTC hour directly would put a 07:00
- * Chicago task in the afternoon slot.
- */
-export function itemTimeOfDayMinutes(item: SlottableItem, timezone: string): number | null {
-  if (item.anchor_time) {
-    const parsed = parseHHMM(item.anchor_time)
-    if (parsed !== null) return parsed
-  }
-  if (!item.due_at) return null
-
-  const local = utcToLocal(item.due_at, timezone)
-  if (!local.isValid) return null
-  return local.hour * 60 + local.minute
-}
-
-/**
- * Assign an item to a slot.
- *
- * §6.0's rule: the slot with the latest `start_time` less than or equal to the
- * item's time of day. An item earlier than every slot boundary, or with no time
- * of day at all, gets null — those render in the un-slotted group ("Anytime
- * today", §7.3) rather than being silently dropped from the front door.
- */
-export function assignSlot(
-  item: SlottableItem,
-  slots: TimeSlot[],
-  timezone: string,
-): TimeSlot | null {
-  const minutes = itemTimeOfDayMinutes(item, timezone)
-  if (minutes === null) return null
-
-  let best: TimeSlot | null = null
-  let bestStart = -1
-  for (const slot of slots) {
-    const start = parseHHMM(slot.start_time)
-    if (start === null || start > minutes) continue
-    if (start > bestStart) {
-      bestStart = start
-      best = slot
-    }
-  }
-  return best
-}
-
-/**
- * Group items into slots, in slot order, with the un-slotted items last.
- *
- * Empty slots are retained: a slot the user defined is part of how they read
- * their day, and silently omitting it makes the view's shape change based on
- * data rather than on their configuration.
- */
-export function groupBySlot<T extends SlottableItem>(
-  items: T[],
-  slots: TimeSlot[],
-  timezone: string,
-): { slot: TimeSlot | null; items: T[] }[] {
-  const ordered = [...slots].sort(
-    (a, b) => (parseHHMM(a.start_time) ?? 0) - (parseHHMM(b.start_time) ?? 0),
-  )
-  const groups = new Map<number | null, T[]>()
-  for (const slot of ordered) groups.set(slot.id, [])
-  groups.set(null, [])
-
-  for (const item of items) {
-    const slot = assignSlot(item, ordered, timezone)
-    groups.get(slot?.id ?? null)!.push(item)
-  }
-
-  const result: { slot: TimeSlot | null; items: T[] }[] = ordered.map((slot) => ({
-    slot,
-    items: groups.get(slot.id)!,
-  }))
-  result.push({ slot: null, items: groups.get(null)! })
-  return result
 }

--- a/src/core/undo/apply-fields.ts
+++ b/src/core/undo/apply-fields.ts
@@ -50,6 +50,8 @@ const VALID_TASK_COLUMNS = new Set([
   'progress_target',
   'progress_current',
   'skip_count',
+  // §6
+  'is_reminder',
 ])
 
 /**
@@ -92,6 +94,10 @@ export function applyFieldsToTask(
       } else if (dbColumn === 'done') {
         setClauses.push(`${dbColumn} = ?`)
         values.push((state as { done?: boolean }).done ? 1 : 0)
+      } else if (dbColumn === 'is_reminder') {
+        // Same reason as `done`: SQLite has no boolean type (§6).
+        setClauses.push(`${dbColumn} = ?`)
+        values.push((state as { is_reminder?: boolean }).is_reminder ? 1 : 0)
       } else {
         setClauses.push(`${dbColumn} = ?`)
         values.push((state as Record<string, unknown>)[stateKey])

--- a/src/core/validation/task.ts
+++ b/src/core/validation/task.ts
@@ -77,6 +77,30 @@ const progressTarget = z.number().int().min(1).max(1000)
 const progressCurrent = z.number().int().min(0).max(10000)
 
 /**
+ * §6: put this item on the Reminders surface.
+ *
+ * A boolean rather than a label because §7.1 rules that kind is never stored as
+ * a name, and the notifier and dashboard both want an indexed column rather
+ * than json_each() over the labels array.
+ */
+const isReminderFlag = z.boolean()
+
+/**
+ * §5/§6 are mutually exclusive: an item is tracked or it is a reminder, never
+ * both. They pull in opposite directions — Track counts occurrences toward a
+ * quota, while a reminder has no debt at all and completing it just means
+ * "considered". A row claiming both has no coherent behavior.
+ */
+function refuseTrackedReminder<T extends { progress_target?: number; is_reminder?: boolean }>(
+  data: T,
+): boolean {
+  return !(data.is_reminder === true && (data.progress_target ?? 1) > 1)
+}
+
+const TRACKED_REMINDER_MESSAGE =
+  'A task cannot be both tracked (progress_target > 1) and a reminder'
+
+/**
  * Auto-snooze minutes: null = use user default, 0 = off, 1-360 = custom minutes
  */
 const autoSnoozeMinutes = z.number().int().min(0).max(360).nullable()
@@ -102,21 +126,24 @@ const bulkIds = z
 /**
  * Task creation input schema
  */
-export const taskCreateSchema = z.object({
-  title: z.string().trim().min(1, 'Title is required').max(10000, 'Title too long'),
-  due_at: dateTimeString.nullable().optional(),
-  rrule: rruleString,
-  recurrence_mode: recurrenceMode.default('from_due').optional(),
-  project_id: z.number().int().positive().optional(),
-  priority: priority.default(0).optional(),
-  labels: labels.default([]).optional(),
-  notes: z.string().max(10000, 'Notes too long').nullable().optional(),
-  auto_snooze_minutes: autoSnoozeMinutes.optional(),
-  create_label: createLabelFlag,
-  ai_proposed: provenanceFlag,
-  ai_added: provenanceFlag,
-  progress_target: progressTarget.optional(),
-})
+export const taskCreateSchema = z
+  .object({
+    title: z.string().trim().min(1, 'Title is required').max(10000, 'Title too long'),
+    due_at: dateTimeString.nullable().optional(),
+    rrule: rruleString,
+    recurrence_mode: recurrenceMode.default('from_due').optional(),
+    project_id: z.number().int().positive().optional(),
+    priority: priority.default(0).optional(),
+    labels: labels.default([]).optional(),
+    notes: z.string().max(10000, 'Notes too long').nullable().optional(),
+    auto_snooze_minutes: autoSnoozeMinutes.optional(),
+    create_label: createLabelFlag,
+    ai_proposed: provenanceFlag,
+    ai_added: provenanceFlag,
+    progress_target: progressTarget.optional(),
+    is_reminder: isReminderFlag.optional(),
+  })
+  .refine(refuseTrackedReminder, { message: TRACKED_REMINDER_MESSAGE })
 
 export type TaskCreateInput = z.infer<typeof taskCreateSchema>
 
@@ -138,6 +165,7 @@ export const taskUpdateSchema = z.object({
   create_label: createLabelFlag,
   progress_target: progressTarget.optional(),
   progress_current: progressCurrent.optional(),
+  is_reminder: isReminderFlag.optional(),
 })
 
 export type TaskUpdateInput = z.infer<typeof taskUpdateSchema>

--- a/src/hooks/useTimeSlots.ts
+++ b/src/hooks/useTimeSlots.ts
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { TimeSlot } from '@/lib/time-slot-assign'
+
+/**
+ * The user's time slots (REDESIGN-V03 §6.0).
+ *
+ * Fetched once per mount. Slots change rarely — they're boundaries the user
+ * configures, not data — so there's no polling and no revalidation on focus.
+ *
+ * Failure returns an empty array rather than throwing. An empty slot list makes
+ * `groupByTimeSlot` put everything in "Anytime today", which is a degraded but
+ * honest view; a thrown error would take down the whole dashboard over what is
+ * effectively presentation metadata.
+ */
+export function useTimeSlots(): { timeSlots: TimeSlot[]; loading: boolean } {
+  const [timeSlots, setTimeSlots] = useState<TimeSlot[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetch('/api/time-slots')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (cancelled) return
+        setTimeSlots(json?.data?.time_slots ?? [])
+      })
+      .catch(() => {
+        if (!cancelled) setTimeSlots([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { timeSlots, loading }
+}

--- a/src/lib/time-slot-assign.ts
+++ b/src/lib/time-slot-assign.ts
@@ -1,0 +1,131 @@
+/**
+ * Time-slot assignment — the pure half (REDESIGN-V03 §6.0)
+ *
+ * Separated from `@/core/time-slots` because that module imports `getDb`, and
+ * the dashboard needs to group by slot on the CLIENT. Importing the core module
+ * from a component would drag better-sqlite3 into the browser bundle.
+ *
+ * NAMING GUARD: this is a **time slot**, never a "bucket" — `bucket` already
+ * names the due-date classifier in useFilterState.ts / DueDateFilterBar.tsx.
+ */
+
+import { DateTime } from 'luxon'
+
+export interface TimeSlot {
+  id: number
+  user_id: number
+  label: string
+  /** HH:MM local */
+  start_time: string
+  sort_order: number
+  created_at: string
+}
+
+/** Seeded from the production clusters measured at spec time (§6.0). */
+export const DEFAULT_TIME_SLOTS: ReadonlyArray<{ label: string; start_time: string }> = [
+  { label: 'Early morning', start_time: '07:00' },
+  { label: 'Before work', start_time: '09:00' },
+  { label: 'Midday', start_time: '12:00' },
+  { label: 'Afternoon', start_time: '16:00' },
+  { label: 'Evening', start_time: '20:30' },
+]
+
+const HHMM = /^([01]\d|2[0-3]):([0-5]\d)$/
+
+export function parseHHMM(value: string): number | null {
+  const match = HHMM.exec(value)
+  if (!match) return null
+  return parseInt(match[1], 10) * 60 + parseInt(match[2], 10)
+}
+
+/**
+ * The item shape slot assignment needs.
+ *
+ * `anchor_time` wins over `due_at` because for a recurring item it is the
+ * *intended* time of day, and §4.6 establishes that a recurring item's `due_at`
+ * cannot be trusted — it only stays fresh while the user keeps sweeping.
+ */
+export interface SlottableItem {
+  anchor_time: string | null
+  due_at: string | null
+}
+
+/**
+ * Resolve an item's local time of day in minutes, or null if it has none.
+ *
+ * `anchor_time` is already local HH:MM. `due_at` is UTC and must be converted
+ * through the user's timezone — reading its UTC hour directly would put a 07:00
+ * Chicago task in the afternoon slot.
+ */
+export function itemTimeOfDayMinutes(item: SlottableItem, timezone: string): number | null {
+  if (item.anchor_time) {
+    const parsed = parseHHMM(item.anchor_time)
+    if (parsed !== null) return parsed
+  }
+  if (!item.due_at) return null
+
+  const local = DateTime.fromISO(item.due_at, { zone: 'utc' }).setZone(timezone)
+  if (!local.isValid) return null
+  return local.hour * 60 + local.minute
+}
+
+/**
+ * Assign an item to a slot.
+ *
+ * §6.0's rule: the slot with the latest `start_time` less than or equal to the
+ * item's time of day. An item earlier than every slot boundary, or with no time
+ * of day at all, gets null — those render in the un-slotted group ("Anytime
+ * today", §7.3) rather than being silently dropped from the front door.
+ */
+export function assignSlot(
+  item: SlottableItem,
+  slots: TimeSlot[],
+  timezone: string,
+): TimeSlot | null {
+  const minutes = itemTimeOfDayMinutes(item, timezone)
+  if (minutes === null) return null
+
+  let best: TimeSlot | null = null
+  let bestStart = -1
+  for (const slot of slots) {
+    const start = parseHHMM(slot.start_time)
+    if (start === null || start > minutes) continue
+    if (start > bestStart) {
+      bestStart = start
+      best = slot
+    }
+  }
+  return best
+}
+
+/**
+ * Group items into slots, in slot order, with the un-slotted items last.
+ *
+ * Empty slots are retained: a slot the user defined is part of how they read
+ * their day, and silently omitting it makes the view's shape change based on
+ * data rather than on their configuration.
+ */
+export function groupBySlot<T extends SlottableItem>(
+  items: T[],
+  slots: TimeSlot[],
+  timezone: string,
+): { slot: TimeSlot | null; items: T[] }[] {
+  const ordered = [...slots].sort(
+    (a, b) => (parseHHMM(a.start_time) ?? 0) - (parseHHMM(b.start_time) ?? 0),
+  )
+  const groups = new Map<number | null, T[]>()
+  for (const slot of ordered) groups.set(slot.id, [])
+  groups.set(null, [])
+
+  for (const item of items) {
+    const slot = assignSlot(item, ordered, timezone)
+    groups.get(slot?.id ?? null)!.push(item)
+  }
+
+  const result: { slot: TimeSlot | null; items: T[] }[] = ordered.map((slot) => ({
+    slot,
+    items: groups.get(slot.id)!,
+  }))
+  result.push({ slot: null, items: groups.get(null)! })
+  return result
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,15 @@ export interface Task {
   progress_target: number
   progress_current: number
 
+  /**
+   * §6: this item lives on the Reminders surface — a prompted thought rather
+   * than an action. Reminders have NO DEBT: they never count as overdue, never
+   * reach the badge, never fire individually, and can't be snoozed out of their
+   * time slot. Completion means "considered", which IS its completion.
+   * Mutually exclusive with Track (progress_target > 1).
+   */
+  is_reminder: boolean
+
   // Per-task stats (survive beyond completions retention)
   completion_count: number
   snooze_count: number

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -191,6 +191,7 @@ export interface AuthUser {
   email: string
   name: string
   timezone: string
-  default_grouping: 'time' | 'project' | 'unified'
+  /** §7.3 adds 'slot' — today grouped by time slot, the new front door. */
+  default_grouping: 'time' | 'project' | 'unified' | 'slot'
   is_demo: boolean
 }

--- a/tests/behavioral/cl-cadence-ladder.test.ts
+++ b/tests/behavioral/cl-cadence-ladder.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Cadence Ladder Tests (CL-001 through CL-008)
+ *
+ * Covers REDESIGN-V03 §4.1. Before this, P0/P1/P2 all fell through to a single
+ * shared interval, which is a large part of why priority behaved as a binary
+ * "matters" flag rather than a ladder. CL-002 and CL-003 are the rungs that
+ * previously didn't exist.
+ */
+
+import { describe, test, expect } from 'vitest'
+import { isNotificationBoundary } from '@/core/notifications/overdue-checker'
+import { NOTIFICATION_THREADS, threadIdForPriority } from '@/core/notifications/apns'
+
+const BASE = {
+  id: 1,
+  title: 'Test',
+  due_at: '2026-01-15T10:00:00.000Z',
+  effective_due_at: '2026-01-15T10:00:00.000Z',
+  user_id: 1,
+  auto_snooze_minutes: null,
+  user_auto_snooze_minutes: 30,
+  user_auto_snooze_urgent_minutes: 5,
+  user_auto_snooze_high_minutes: 15,
+  user_auto_snooze_low_minutes: 240,
+  user_auto_snooze_medium_minutes: 60,
+  critical_alert_volume: 1.0,
+  rrule: null,
+  recurrence_mode: 'from_due' as const,
+  anchor_time: null,
+  timezone: 'America/Chicago',
+}
+
+/** Does a task of this priority fire `minutes` after becoming due? */
+function firesAt(priority: number, minutes: number): boolean {
+  const now = new Date(new Date(BASE.effective_due_at).getTime() + minutes * 60_000)
+  return isNotificationBoundary({ ...BASE, priority }, now)
+}
+
+describe('Cadence ladder', () => {
+  /**
+   * CL-001: P0 keeps 30 min. Unchanged deliberately — unset means nobody stated
+   * a priority (L1), and per L2 silence fails dangerous, so an
+   * urgent-but-unclassified item must still reach the user.
+   */
+  test('CL-001: P0 repeats every 30 minutes', () => {
+    expect(firesAt(0, 30)).toBe(true)
+    expect(firesAt(0, 60)).toBe(true)
+    expect(firesAt(0, 45)).toBe(false)
+  })
+
+  /**
+   * CL-002: P1 is rare — a few times a day — but never silent.
+   */
+  test('CL-002: P1 repeats every 240 minutes', () => {
+    expect(firesAt(1, 240)).toBe(true)
+    expect(firesAt(1, 480)).toBe(true)
+    expect(firesAt(1, 30)).toBe(false)
+    expect(firesAt(1, 60)).toBe(false)
+  })
+
+  /**
+   * CL-003: P2 is hourly and explicitly NOT notify-once. One missed glance —
+   * phone face-down, in a meeting — would lose it permanently, which fails
+   * dangerous for something rated moderately important.
+   */
+  test('CL-003: P2 repeats hourly rather than firing once', () => {
+    expect(firesAt(2, 60)).toBe(true)
+    expect(firesAt(2, 120)).toBe(true)
+    expect(firesAt(2, 30)).toBe(false)
+  })
+
+  /**
+   * CL-004 / CL-005: the upper rungs are unchanged.
+   */
+  test('CL-004: P3 repeats every 15 minutes', () => {
+    expect(firesAt(3, 15)).toBe(true)
+    expect(firesAt(3, 30)).toBe(true)
+    expect(firesAt(3, 20)).toBe(false)
+  })
+
+  test('CL-005: P4 repeats every 5 minutes', () => {
+    expect(firesAt(4, 5)).toBe(true)
+    expect(firesAt(4, 10)).toBe(true)
+    expect(firesAt(4, 7)).toBe(false)
+  })
+
+  /**
+   * CL-006: The rungs are genuinely distinct. Previously P0, P1 and P2 shared
+   * one value, so this is the assertion that would have failed before.
+   */
+  test('CL-006: P0, P1 and P2 no longer share one interval', () => {
+    // 240 min is a P1 boundary but not a P2 one... and both differ from P0.
+    expect(firesAt(1, 240)).toBe(true)
+    expect(firesAt(2, 90)).toBe(false)
+    expect(firesAt(0, 90)).toBe(true)
+  })
+
+  /**
+   * CL-007: A per-task override still wins over every tier.
+   */
+  test('CL-007: per-task auto_snooze_minutes overrides the tier', () => {
+    const now = new Date(new Date(BASE.effective_due_at).getTime() + 10 * 60_000)
+    expect(isNotificationBoundary({ ...BASE, priority: 1, auto_snooze_minutes: 10 }, now)).toBe(
+      true,
+    )
+  })
+
+  /**
+   * CL-008: An override of 0 disables notifications entirely. Verified in
+   * source but effectively untested in production (§4.1's warning), so it is
+   * pinned here.
+   */
+  test('CL-008: an auto_snooze_minutes of 0 silences the task', () => {
+    for (const minutes of [5, 30, 60, 240]) {
+      const now = new Date(new Date(BASE.effective_due_at).getTime() + minutes * 60_000)
+      expect(isNotificationBoundary({ ...BASE, priority: 4, auto_snooze_minutes: 0 }, now)).toBe(
+        false,
+      )
+    }
+  })
+
+  /**
+   * CL-009: §4.2 — urgent gets its own visible stack so it can't be lost among
+   * routine items.
+   */
+  test('CL-009: urgent tasks thread separately from ordinary ones', () => {
+    expect(threadIdForPriority(4)).toBe(NOTIFICATION_THREADS.urgent)
+    expect(threadIdForPriority(3)).toBe(NOTIFICATION_THREADS.tasks)
+    expect(threadIdForPriority(0)).toBe(NOTIFICATION_THREADS.tasks)
+    expect(NOTIFICATION_THREADS.urgent).not.toBe(NOTIFICATION_THREADS.tasks)
+    expect(NOTIFICATION_THREADS.reminders).not.toBe(NOTIFICATION_THREADS.tasks)
+  })
+})

--- a/tests/behavioral/dv-dashboard-view.test.ts
+++ b/tests/behavioral/dv-dashboard-view.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Dashboard Slot View Tests (DV-001 through DV-009)
+ *
+ * Covers REDESIGN-V03 §7.3's grouping rules. The dashboard's own rendering is
+ * E2E territory; what's pinned here is the pure grouping logic underneath it,
+ * because that's where the failures are silent — an item quietly missing from
+ * the front door looks identical to an empty day.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { DateTime } from 'luxon'
+import { groupBySlot, type TimeSlot } from '@/lib/time-slot-assign'
+import { effectiveDueAt } from '@/core/recurrence/occurrence'
+
+const TZ = 'America/Chicago'
+const NOW = new Date('2026-01-15T16:00:00Z') // Thursday, 10:00 local
+
+const SLOTS: TimeSlot[] = [
+  { id: 1, user_id: 1, label: 'Early morning', start_time: '07:00', sort_order: 0, created_at: '' },
+  { id: 2, user_id: 1, label: 'Before work', start_time: '09:00', sort_order: 1, created_at: '' },
+  { id: 3, user_id: 1, label: 'Midday', start_time: '12:00', sort_order: 2, created_at: '' },
+  { id: 4, user_id: 1, label: 'Evening', start_time: '20:30', sort_order: 3, created_at: '' },
+]
+
+function localIso(dayOffset: number, hour: number, minute = 0): string {
+  return DateTime.fromISO('2026-01-15T00:00:00', { zone: TZ })
+    .plus({ days: dayOffset })
+    .set({ hour, minute, second: 0, millisecond: 0 })
+    .toUTC()
+    .toISO()!
+}
+
+/** Mirrors groupByTimeSlot's today-filter in TaskList. */
+function todaysOnly(
+  items: { due_at: string | null; rrule: string | null; anchor_time: string | null }[],
+) {
+  const endOfToday = DateTime.fromJSDate(NOW).setZone(TZ).endOf('day').toJSDate()
+  return items.filter((task) => {
+    if (!task.due_at && !task.rrule) return true
+    const effective = effectiveDueAt({ ...task, recurrence_mode: 'from_due' }, TZ, NOW)
+    if (!effective) return false
+    return effective.getTime() <= endOfToday.getTime()
+  })
+}
+
+describe('Dashboard slot view', () => {
+  beforeEach(() => vi.setSystemTime(NOW))
+  afterEach(() => vi.useRealTimers())
+
+  /**
+   * DV-001: Items land in the slot matching their time of day.
+   */
+  test('DV-001: tasks group into their time slot', () => {
+    const items = [
+      { anchor_time: '07:30', due_at: localIso(0, 7, 30), rrule: null },
+      { anchor_time: '21:00', due_at: localIso(0, 21), rrule: null },
+    ]
+    const groups = groupBySlot(items, SLOTS, TZ)
+
+    expect(groups.find((g) => g.slot?.label === 'Early morning')?.items).toHaveLength(1)
+    expect(groups.find((g) => g.slot?.label === 'Evening')?.items).toHaveLength(1)
+  })
+
+  /**
+   * DV-002: Un-slotted items go last, never dropped. §7.3 is explicit that
+   * no-time-of-day items — mostly Track — must stay visible from the front door.
+   */
+  test('DV-002: items with no time of day land in the trailing un-slotted group', () => {
+    const items = [
+      { anchor_time: null, due_at: null, rrule: null },
+      { anchor_time: '07:30', due_at: localIso(0, 7, 30), rrule: null },
+    ]
+    const groups = groupBySlot(items, SLOTS, TZ)
+    const last = groups[groups.length - 1]
+
+    expect(last.slot).toBeNull()
+    expect(last.items).toHaveLength(1)
+  })
+
+  /**
+   * DV-003: Slots keep chronological order regardless of input order.
+   */
+  test('DV-003: slots render in time order', () => {
+    const groups = groupBySlot([], SLOTS, TZ)
+    const labels = groups.filter((g) => g.slot).map((g) => g.slot!.label)
+    expect(labels).toEqual(['Early morning', 'Before work', 'Midday', 'Evening'])
+  })
+
+  /**
+   * DV-004: The front door is TODAY. A task due tomorrow is filtered out.
+   */
+  test('DV-004: tomorrow is excluded from the slot view', () => {
+    const items = [
+      { due_at: localIso(1, 9), rrule: null, anchor_time: null },
+      { due_at: localIso(0, 9), rrule: null, anchor_time: null },
+    ]
+    expect(todaysOnly(items)).toHaveLength(1)
+  })
+
+  /**
+   * DV-005: Overdue work still belongs to today — it's what "what now" means.
+   */
+  test('DV-005: overdue tasks remain in the today view', () => {
+    const items = [{ due_at: localIso(-3, 9), rrule: null, anchor_time: null }]
+    expect(todaysOnly(items)).toHaveLength(1)
+  })
+
+  /**
+   * DV-006: A recurring item scheduled today appears even though its stored
+   * due_at froze months ago — the §4.6 derivation, not raw due_at.
+   */
+  test('DV-006: a recurring task due today appears despite a stale due_at', () => {
+    const items = [{ due_at: localIso(-90, 7), rrule: 'FREQ=DAILY', anchor_time: '07:00' }]
+    expect(todaysOnly(items)).toHaveLength(1)
+  })
+
+  /**
+   * DV-007: ...and one NOT scheduled today is absent, however stale it looks.
+   * This is what stops the front door filling with items that aren't today's.
+   */
+  test('DV-007: a recurring task not scheduled today is excluded', () => {
+    // Evaluated on a Thursday; recurs Mondays.
+    const items = [
+      { due_at: localIso(-60, 9), rrule: 'FREQ=WEEKLY;BYDAY=MO', anchor_time: '09:00' },
+    ]
+    expect(todaysOnly(items)).toHaveLength(0)
+  })
+
+  /**
+   * DV-008: Undated items are kept — they can't be "not today", and dropping
+   * them would hide most Track items from the front door.
+   */
+  test('DV-008: undated items are kept in the today view', () => {
+    const items = [{ due_at: null, rrule: null, anchor_time: null }]
+    expect(todaysOnly(items)).toHaveLength(1)
+  })
+
+  /**
+   * DV-009: Empty slots survive grouping — a slot the user defined is part of
+   * how they read their day, so the view's shape follows their configuration
+   * rather than the data.
+   */
+  test('DV-009: empty slots are retained when the day is not empty', () => {
+    const groups = groupBySlot([{ anchor_time: '07:30', due_at: null }], SLOTS, TZ)
+    expect(groups.filter((g) => g.slot).length).toBe(SLOTS.length)
+  })
+})

--- a/tests/behavioral/export.test.ts
+++ b/tests/behavioral/export.test.ts
@@ -274,6 +274,7 @@ function makeFakeTask(overrides: Partial<FormattedTask>): FormattedTask {
     title: 'Test task',
     original_title: null,
     progress_target: 1,
+    is_reminder: false,
     progress_current: 0,
     skip_count: 0,
     done: false,

--- a/tests/behavioral/format-task-clipboard.test.ts
+++ b/tests/behavioral/format-task-clipboard.test.ts
@@ -30,6 +30,7 @@ function makeTask(overrides: Partial<Task> & { id: number; title: string }): Tas
     done: false,
     done_at: null,
     progress_target: 1,
+    is_reminder: false,
     progress_current: 0,
     skip_count: 0,
     priority: 0,

--- a/tests/behavioral/notification-timing.test.ts
+++ b/tests/behavioral/notification-timing.test.ts
@@ -70,6 +70,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -95,6 +97,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -120,6 +124,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -144,6 +150,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -173,6 +181,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -199,6 +209,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -228,6 +240,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -255,6 +269,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -282,6 +298,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -312,6 +330,8 @@ describe('isNotificationBoundary', () => {
       user_auto_snooze_minutes: 30,
       user_auto_snooze_urgent_minutes: 5,
       user_auto_snooze_high_minutes: 15,
+      user_auto_snooze_low_minutes: 240,
+      user_auto_snooze_medium_minutes: 60,
       critical_alert_volume: 1.0,
       // §4.6: these fixtures are non-recurring, so the effective due time is
       // just due_at. Recurring derivation is covered in oc-occurrence.test.ts.
@@ -452,7 +472,11 @@ describe('checkOverdueTasks', () => {
     insertTask(1, 'Task A', '2026-01-15T10:00:00.000Z', 0)
     insertTask(2, 'Task B', '2026-01-15T10:00:00.000Z', 1)
 
-    await checkOverdueTasks(new Date('2026-01-15T10:30:00.000Z'))
+    // Evaluated 240 min out, not 30: under the §4.1 ladder P0 (30), P1 (240)
+    // and P2 (60) have different cadences, and 240 is the first tick where all
+    // three coincide. This test is about the consolidation CAP, so it needs a
+    // moment when every tier actually fires.
+    await checkOverdueTasks(new Date('2026-01-15T14:00:00.000Z'))
 
     // Under the cap of 4, so both get individual web push + APNs
     expect(sendPushNotification).toHaveBeenCalledTimes(2)
@@ -513,7 +537,8 @@ describe('consolidation caps', () => {
     insertTask(5, 'P2-A', '2026-01-15T10:00:00.000Z', 2)
     insertTask(6, 'P2-B', '2026-01-15T10:00:00.000Z', 2)
 
-    await checkOverdueTasks(new Date('2026-01-15T10:30:00.000Z'))
+    // 240 min: the first tick where P0/P1/P2 cadences coincide (§4.1).
+    await checkOverdueTasks(new Date('2026-01-15T14:00:00.000Z'))
 
     // 4 individual + 1 summary = 5 web push
     expect(sendPushNotification).toHaveBeenCalledTimes(5)

--- a/tests/behavioral/rm-reminders.test.ts
+++ b/tests/behavioral/rm-reminders.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Reminders Surface Behavioral Tests (RM-001 through RM-014)
+ *
+ * Covers REDESIGN-V03 §6. Reminders are prompted thoughts, not actions, and
+ * they differ BEHAVIOURALLY from tasks — which is why they get a surface rather
+ * than a tag. The load-bearing property is that they carry NO DEBT: RM-004
+ * through RM-007 are the tests that enforce it.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { getDb } from '@/core/db'
+import { createTask, getTaskById, updateTask, bulkSnooze } from '@/core/tasks'
+import { snoozeTask } from '@/core/tasks/snooze'
+import { getTodaysReminders, getRemindersBySlot } from '@/core/tasks/reminders'
+import { getCurrentlyDueTaskIds } from '@/core/tasks/currently-due'
+import { getOverdueCount } from '@/core/notifications/dismiss'
+import { validateTaskCreate } from '@/core/validation'
+import { executeUndo } from '@/core/undo'
+import { ValidationError } from '@/core/errors'
+import { ZodError } from 'zod'
+import {
+  setupTestDb,
+  teardownTestDb,
+  localTime,
+  TEST_TIMEZONE,
+  TEST_USER_ID,
+} from '../helpers/setup'
+
+function makeReminder(overrides: Record<string, unknown> = {}) {
+  return createTask({
+    userId: TEST_USER_ID,
+    userTimezone: TEST_TIMEZONE,
+    input: {
+      title: 'Depressed = Past, Anxious = Future',
+      is_reminder: true,
+      rrule: 'FREQ=DAILY',
+      due_at: localTime(7, 0),
+      ...overrides,
+    },
+  })
+}
+
+describe('Reminders surface', () => {
+  beforeEach(() => {
+    // Thursday 2026-01-15, 10:00 local
+    vi.setSystemTime(new Date('2026-01-15T16:00:00Z'))
+    setupTestDb()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    teardownTestDb()
+  })
+
+  /**
+   * RM-001: The flag is a real column, not a label (§7.1 — kind is never
+   * stored as a name).
+   */
+  test('RM-001: is_reminder round-trips as a boolean column', () => {
+    const reminder = makeReminder()
+    expect(reminder.is_reminder).toBe(true)
+    expect(getTaskById(reminder.id)!.is_reminder).toBe(true)
+
+    const plain = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Plain' },
+    })
+    expect(plain.is_reminder).toBe(false)
+  })
+
+  /**
+   * RM-002: §5 and §6 are mutually exclusive — an item is tracked or a
+   * reminder, never both. They pull in opposite directions.
+   */
+  test('RM-002: a task cannot be both tracked and a reminder', () => {
+    expect(() =>
+      validateTaskCreate({ title: 'Both', is_reminder: true, progress_target: 3 }),
+    ).toThrow(ZodError)
+  })
+
+  /**
+   * RM-003: Either alone is fine.
+   */
+  test('RM-003: tracked-only and reminder-only both validate', () => {
+    expect(() => validateTaskCreate({ title: 'Tracked', progress_target: 3 })).not.toThrow()
+    expect(() => validateTaskCreate({ title: 'Reminder', is_reminder: true })).not.toThrow()
+  })
+
+  /**
+   * RM-004: NO DEBT — a reminder is never counted as due, however overdue its
+   * due_at looks. This is what stops the Reminders population inflating the
+   * very overdue pile the redesign exists to shrink.
+   */
+  test('RM-004: reminders never appear in the currently-due set', () => {
+    const reminder = makeReminder({ due_at: localTime(7, 0) })
+    const plain = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Real task', due_at: localTime(7, 0) },
+    })
+
+    const due = getCurrentlyDueTaskIds(TEST_USER_ID)
+    expect(due).toContain(plain.id)
+    expect(due).not.toContain(reminder.id)
+  })
+
+  /**
+   * RM-005: ...and therefore never reach the badge.
+   */
+  test('RM-005: reminders are excluded from the badge count', () => {
+    makeReminder({ due_at: localTime(7, 0) })
+    expect(getOverdueCount(TEST_USER_ID)).toBe(0)
+
+    createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Real task', due_at: localTime(7, 0) },
+    })
+    expect(getOverdueCount(TEST_USER_ID)).toBe(1)
+  })
+
+  /**
+   * RM-006: Bucket-locked — a reminder cannot be snoozed out of its slot. It
+   * stays visible until completed, because completion ("I considered it") is
+   * the entire interaction.
+   */
+  test('RM-006: snoozing a reminder is rejected', () => {
+    const reminder = makeReminder()
+    expect(() =>
+      snoozeTask({
+        userId: TEST_USER_ID,
+        userTimezone: TEST_TIMEZONE,
+        taskId: reminder.id,
+        until: localTime(20, 0),
+      }),
+    ).toThrow(ValidationError)
+  })
+
+  /**
+   * RM-007: A bulk sweep skips reminders SILENTLY and reports a count — §4.3
+   * forbids bulk paths from modal-blocking, and per L1 sweep participation
+   * carries no per-item intent worth confirming.
+   */
+  test('RM-007: bulk snooze skips reminders and reports the count', () => {
+    const reminder = makeReminder({ due_at: localTime(7, 0) })
+    const plain = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Real task', due_at: localTime(7, 0), priority: 1 },
+    })
+
+    const result = bulkSnooze({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskIds: [reminder.id, plain.id],
+      until: localTime(20, 0),
+    })
+
+    expect(result.tasksAffected).toBe(1)
+    expect(result.reminderSkipped).toBe(1)
+    expect(getTaskById(reminder.id)!.due_at).toBe(localTime(7, 0))
+  })
+
+  /**
+   * RM-008: include_task_ids does NOT rescue a reminder — the constraint is
+   * about what a reminder IS, not how deliberately it was picked.
+   */
+  test('RM-008: an explicit selection still cannot snooze a reminder', () => {
+    const reminder = makeReminder({ due_at: localTime(7, 0) })
+
+    const result = bulkSnooze({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskIds: [reminder.id],
+      until: localTime(20, 0),
+      includeTaskIds: [reminder.id],
+    })
+
+    expect(result.tasksAffected).toBe(0)
+    expect(result.reminderSkipped).toBe(1)
+  })
+
+  /**
+   * RM-009: Today's reminders are derived from the schedule (§4.6), so one
+   * scheduled for another day simply isn't shown — no debt accrues.
+   */
+  test('RM-009: a reminder not scheduled today is not in today list', () => {
+    // 2026-01-15 is a Thursday.
+    const today = makeReminder({ rrule: 'FREQ=WEEKLY;BYDAY=TH', anchor_time: '07:00' })
+    const otherDay = makeReminder({ rrule: 'FREQ=WEEKLY;BYDAY=MO', title: 'Monday thought' })
+
+    const ids = getTodaysReminders(TEST_USER_ID, TEST_TIMEZONE).map((t) => t.id)
+    expect(ids).toContain(today.id)
+    expect(ids).not.toContain(otherDay.id)
+  })
+
+  /**
+   * RM-010: Completed reminders drop out of the bucket rather than sitting
+   * there greyed out — leaving them would bury the ones still worth
+   * considering.
+   */
+  test('RM-010: completed reminders leave the bucket', () => {
+    const reminder = makeReminder()
+    expect(getTodaysReminders(TEST_USER_ID, TEST_TIMEZONE).map((t) => t.id)).toContain(reminder.id)
+
+    getDb().prepare('UPDATE tasks SET done = 1 WHERE id = ?').run(reminder.id)
+    expect(getTodaysReminders(TEST_USER_ID, TEST_TIMEZONE).map((t) => t.id)).not.toContain(
+      reminder.id,
+    )
+  })
+
+  /**
+   * RM-011: Reminders group into the SAME time slots the dashboard uses, so
+   * "morning" means one thing across the app.
+   */
+  test('RM-011: reminders group by time slot', () => {
+    makeReminder({ anchor_time: '07:00', due_at: localTime(7, 0) })
+    makeReminder({ title: 'Evening thought', anchor_time: '20:30', due_at: localTime(20, 30) })
+
+    const groups = getRemindersBySlot(TEST_USER_ID, TEST_TIMEZONE)
+    const morning = groups.find((g) => g.slot?.label === 'Early morning')
+    const evening = groups.find((g) => g.slot?.label === 'Evening')
+
+    expect(morning?.reminders).toHaveLength(1)
+    expect(evening?.reminders).toHaveLength(1)
+  })
+
+  /**
+   * RM-012: Priority is PROMINENCE, not interruption — within a slot, higher
+   * priority sorts first. The canonical high-priority reminder is important
+   * without being an interrupt.
+   */
+  test('RM-012: higher priority sorts first within a slot', () => {
+    makeReminder({ title: 'Low thought', anchor_time: '07:00', priority: 0 })
+    makeReminder({ title: 'Supplements', anchor_time: '07:00', priority: 3 })
+
+    const morning = getRemindersBySlot(TEST_USER_ID, TEST_TIMEZONE).find(
+      (g) => g.slot?.label === 'Early morning',
+    )
+    expect(morning?.reminders[0].title).toBe('Supplements')
+  })
+
+  /**
+   * RM-013: A high-priority reminder STILL never notifies. Priority changes
+   * position, never interruption — that is the §6 carve-out in one assertion.
+   */
+  test('RM-013: even an urgent reminder never becomes due', () => {
+    makeReminder({ priority: 4, due_at: localTime(7, 0) })
+    expect(getCurrentlyDueTaskIds(TEST_USER_ID)).toHaveLength(0)
+  })
+
+  /**
+   * RM-014: An existing task can be moved onto the surface, and undo restores
+   * it. VALID_TASK_COLUMNS must contain is_reminder or the undo throws.
+   */
+  test('RM-014: toggling is_reminder is undoable', () => {
+    const task = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Becomes a reminder' },
+    })
+
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: task.id,
+      input: { is_reminder: true },
+    })
+    expect(getTaskById(task.id)!.is_reminder).toBe(true)
+
+    executeUndo(TEST_USER_ID)
+    expect(getTaskById(task.id)!.is_reminder).toBe(false)
+  })
+})


### PR DESCRIPTION
Stage 2 (server-side) + Stage 3 of the v0.3 Trust Redesign. Branched off `main`, which already has Stage 0 + Stage 1.

## §6 — Reminders surface (backend)

Prompted thoughts get an `is_reminder` boolean column, deliberately **not** a label: §7.1 rules kind is never stored as a name, and a behavior-bearing value inside the JSON labels array would need `json_each()` at every query site wanting an indexed boolean.

The load-bearing property is **no debt** — never in overdue, never in the badge, never fire individually, and cannot be snoozed out of their slot. A bulk sweep skips them silently and reports a count (§4.3 forbids bulk prompts). `include_task_ids` deliberately does *not* rescue them: the constraint is about what a reminder is, not how deliberately it was picked.

## §7.3 — Today-by-time-slot dashboard

The new front door. Which tasks count as "today" comes from §4.6's derivation, not raw `due_at`. Un-slotted items get an explicit trailing "Anytime today" group rather than being dropped. Groups show first 5 with "show all" one tap away — nothing is ever truncated permanently (§1.1).

Adds `ViewModeToggle` because **no grouping control existed in the UI at all**; without one the older views would become unreachable.

## §4.1 — The cadence ladder

`getEffectiveInterval` now branches on every rung. Previously P0/P1/P2 all fell through to one shared value, which is part of why priority behaved as a binary flag.

| P | Interval | Note |
|---|---|---|
| 0 | 30 min | unchanged — L2 failure-safe |
| 1 | 240 min | rare, never silent |
| 2 | 60 min | **not** notify-once — one missed glance would lose it |
| 3 | 15 min | unchanged |
| 4 | 5 min | unchanged |

Settings is now five rows. §4.2 gives urgent its own notification thread. §6.1 adds `POST /api/tasks/bulk/complete` — the batch checklist must commit N completions in one request, since the extension can be suspended mid-flight.

## §9 — Classification dry-run (writes nothing)

Included with a **negative finding**: structural classification does not work on this corpus. Bracket prefixes encode *time of day*, not kind — `[A]` is afternoon, and an earlier pass mislabelled all 28 afternoon tasks as thoughts. Kind is mixed *within* a prefix. The heuristic returns 202/6/2/7 against §3's expected ~108/40/45/12 and flags 210 of 217 as needing a decision, which is not a review list.

Only the quota parse is trustworthy. The rest needs the AI pass §9 actually specifies. Left honest rather than tuned — output feeds a one-shot migration over live data.

## Verification

- 45 behavioral, 23 integration, 25 E2E — all green; lint 0 errors
- 32 new behavioral tests (RM/DV/CL)
- Deployed to dev; slot view, "Anytime today", show-all/less, five settings rows, and batch-complete all verified in-browser at 1440x900 and 375x812. Zero console errors.

## Known / not included

- **Reminders surface UI not built** — it would render empty until migration flags reminders. Backend and API are ready.
- Filter chip density above the task list is unchanged, so §7.3's "20 chips" complaint is only half addressed.
- iOS batch-checklist extension needs a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
