### PR TITLE
Rapid-tapping +1 no longer opens the quota editor on top of the count

### DIFF
--- a/src/components/QuotasView.tsx
+++ b/src/components/QuotasView.tsx
@@ -14,7 +14,7 @@ import { trackSummary, groupByPeriod, periodShort } from '@/lib/track'
 import { trackedItems } from '@/lib/slot-view'
 import { showToast } from '@/lib/toast'
 import { log } from '@/lib/logger'
-import { cn } from '@/lib/utils'
+import { cn, fromRowControl } from '@/lib/utils'
 import type { Task } from '@/types'
 
 /**
@@ -102,7 +102,11 @@ export function QuotasView({
   // The sidebar's button and the phone's plus reach this surface through an
   // event, the way Reminders does, so "add" on /quotas makes a quota.
   useEffect(() => {
-    const open = () => setCreating({ title: '' })
+    // Idempotent: a second event while the form is already open is a no-op
+    // rather than a fresh draft. A double-tap on the phone's plus dispatches
+    // twice, and re-setting the draft threw away anything already typed and
+    // re-ran the modal's open effects.
+    const open = () => setCreating((current) => current ?? { title: '' })
     window.addEventListener('open-add-quota', open)
     return () => window.removeEventListener('open-add-quota', open)
   }, [])
@@ -316,7 +320,12 @@ function QuotaRow({
       // modal is handed the task directly, not the selection, so it still gets
       // the right one.
       onClick={onSelect}
-      onDoubleClick={onOpen}
+      // Not when the double-click was on the +1/-1 buttons: those stop the
+      // row's click, but dblclick is its own event and bubbles regardless.
+      onDoubleClick={(e) => {
+        if (fromRowControl(e)) return
+        onOpen()
+      }}
       className={cn(
         // Wraps like TrackRow: on a phone the title takes the whole first line
         // and the bar/count/buttons sit beneath it. Five fixed-width things on

--- a/src/components/RemindersView.tsx
+++ b/src/components/RemindersView.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Check, CheckCheck, ChevronDown, ChevronRight, Lightbulb, StickyNote } from 'lucide-react'
 import { DateTime } from 'luxon'
-import { cn } from '@/lib/utils'
+import { cn, fromRowControl } from '@/lib/utils'
 import { currentSlot, parseHHMM, type TimeSlot } from '@/lib/time-slot-assign'
 import { summarizeReminders, type RemindersSummary } from '@/lib/reminders-summary'
 import { cadenceMark, slotAtMinutes } from '@/lib/reminder-rule'
@@ -1247,7 +1247,13 @@ function ReminderRow({
       // bring up the modal"). Its two clicks select and then deselect the row
       // (a lone selection toggles), so afterwards nothing is selected — the
       // dashboard's double-click leaves the same state.
-      onDoubleClick={() => onOpen(reminder)}
+      // Same guard the quota rows use: the check circle and Retry stop the
+      // row's click, but dblclick travels separately and would open this on
+      // top of whatever the button just did.
+      onDoubleClick={(e) => {
+        if (fromRowControl(e)) return
+        onOpen(reminder)
+      }}
       className={cn(
         // The border is always there, transparent, so the processing pulse has
         // something to color without the row shifting by a pixel.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,29 @@ export function isMacPlatform(): boolean {
   if (typeof navigator === 'undefined') return false
   return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent)
 }
+
+/**
+ * True when a double-click landed on a control inside the row rather than on
+ * the row itself.
+ *
+ * Rows on the list surfaces open their editor on double-click, and the buttons
+ * inside them stop the row's `click`. That is not enough: `dblclick` is a
+ * SEPARATE event with its own trip up the tree, so stopping `click` leaves it
+ * untouched and the row opens anyway. Trent, 2026-09-06, on a quota's +1:
+ * "if I double-tap the +1 on Broccoli Avocado, then the modal pops up" — the
+ * two clicks logged +2 (rapid-tapping a count is the point of that button) and
+ * the dblclick behind them opened the editor on top.
+ *
+ * Guarding here rather than on each button is deliberate: the per-button rule
+ * has now been forgotten twice, and a control added later inherits this one for
+ * free. The `contains` check keeps a control that WRAPS the row from matching.
+ */
+export function fromRowControl(e: {
+  target: EventTarget | null
+  currentTarget: EventTarget | null
+}) {
+  const el = e.target as HTMLElement | null
+  const control = el?.closest?.('button, a, input, textarea, select, [role="button"]')
+  const row = e.currentTarget as HTMLElement | null
+  return !!control && !!row && row !== control && row.contains(control)
+}

--- a/tests/e2e/snooze-guard.spec.ts
+++ b/tests/e2e/snooze-guard.spec.ts
@@ -64,9 +64,15 @@ test.describe('Snooze guards', () => {
     authenticatedPage: page,
   }) => {
     const title = 'Guard daily task'
-    // Due earlier today so the row is overdue and the menu offers "Tomorrow",
-    // which lands past tomorrow's 08:00 occurrence.
-    const dueAt = DateTime.now().set({ hour: 8, minute: 0, second: 0, millisecond: 0 })
+    // Due at the most recent 08:00 that has ALREADY PASSED, so the row is
+    // overdue and the menu offers "Tomorrow", which lands past the next
+    // occurrence. Anchoring on "08:00 today" was a latent time bomb: run the
+    // suite before 08:00 and that timestamp is in the future, the row is not
+    // overdue, and the menu this test needs never appears. CI runs in UTC, so
+    // it failed every night between 00:00 and 08:00 UTC while passing all day
+    // locally (found 2026-09-06, reproduced with TZ=UTC on clean main).
+    let dueAt = DateTime.now().set({ hour: 8, minute: 0, second: 0, millisecond: 0 })
+    if (dueAt > DateTime.now()) dueAt = dueAt.minus({ days: 1 })
     await createTask(page, {
       title,
       due_at: dueAt.toUTC().toISO(),

--- a/tests/e2e/track.spec.ts
+++ b/tests/e2e/track.spec.ts
@@ -379,4 +379,41 @@ test.describe('Quotas page', () => {
       await deleteTasks(page, ids)
     }
   })
+
+  /**
+   * Rapid-tapping +1 is how a count gets to three, so the two clicks must both
+   * land — but the dblclick riding behind them must not also open the editor.
+   * The buttons stop the row's `click`; `dblclick` is a separate event that
+   * ignored that, which is exactly what Trent hit (2026-09-06): "if I
+   * double-tap the +1 on Broccoli Avocado, then the modal pops up".
+   */
+  test('double-tapping +1 counts twice and does not open the editor', async ({
+    authenticatedPage: page,
+  }) => {
+    const id = await createTask(page, {
+      title: 'Probe rapid tap',
+      progress_target: 5,
+      rrule: 'FREQ=WEEKLY',
+    })
+    try {
+      await page.goto('/quotas')
+      const row = page.locator(`[data-quota-row="${id}"]`)
+      await expect(row.locator('[data-quota-count]')).toHaveText('0 / 5')
+
+      await row.getByRole('button', { name: /Log one more/ }).dblclick()
+
+      // Both taps counted...
+      await expect(row.locator('[data-quota-count]')).toHaveText('2 / 5')
+      // ...and nothing opened on top of them.
+      await expect(page.getByRole('dialog')).toHaveCount(0)
+
+      // The row itself still opens on a double-click — the guard is about where
+      // the click landed, not about disabling the gesture.
+      await row.getByText('Probe rapid tap').dblclick()
+      await expect(page.getByRole('dialog')).toBeVisible()
+      await page.keyboard.press('Escape')
+    } finally {
+      await deleteTasks(page, [id])
+    }
+  })
 })


### PR DESCRIPTION
Trent hit this daily and reproduced it on desktop and phone: double-tapping a quota's **+1** logs the two taps (correct) and then opens the editor on top (not correct).

## Cause

The row opens its editor on `onDoubleClick`, and the +1/−1 buttons call `stopPropagation()` on `click`. `dblclick` is a **separate event** with its own trip up the tree — stopping `click` does nothing to it, so it reached the row's handler regardless.

## Fix

Guarded at the row, not on each button. The per-button rule had already been forgotten on four controls across two surfaces; `fromRowControl()` asks whether the double-click landed on an interactive descendant of the row, so a control added later inherits the guard for free. Reminders had the identical hole on its check circle and Retry link.

The counting is untouched — rapid-tapping to three is the point of that button.

## Test

`tests/e2e/track.spec.ts` asserts both halves: two taps still count, no dialog appears. **Verified by reverting the guard** — the test fails with `dialogs=1`, so it genuinely covers the regression.

## Reverts the speculative guard from the previous revision

The `data-add-trigger` / `onInteractOutside` code was written against my guess at this bug, and the guess was wrong. Probed on dev with the modal open: `elementFromPoint` at the Add button resolves to the Radix overlay under `body { pointer-events: none }`, so the guard could never match. Dead code, removed. The idempotent `open-add-quota` from that revision is kept — correct on its own merits.

## Verification

Deployed to dev, probed at 1280 and 375 on the **demo** account (probe rows deleted afterwards, no real data touched):

- +1 double-click → `2 / 5`, zero dialogs, still on `/quotas`
- −1 double-click → `0 / 5`, zero dialogs
- double-click the row itself → editor opens (gesture redirected, not disabled)
- Reminders: row double-click opens; check-circle double-click completes without opening
- No console errors or warnings

1024 behavioral pass, 0 lint errors.

**Note on the E2E suite:** three full runs produced 2, 0 and 1 failures with a *different* test each time (`dashboard.spec.ts:38`, `track.spec.ts:59`, `snooze-guard.spec.ts:112`) — all pass in isolation, and the suite is `workers: 1` with a DB wiped per run. Pre-existing order-dependent flakiness, not introduced here; CI's `retries: 2` absorbs it. Worth its own look later.