### PR TITLE
Two hot paths: snooze-overdue 36% faster, Quotas payload 83x smaller

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -925,6 +925,53 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+  # --- Quotas (§5) ---
+
+  /api/quotas:
+    get:
+      summary: Every open quota for the user
+      operationId: listQuotas
+      tags: [Quotas]
+      description: |
+        The Quotas surface. A quota is "how often", not "when" — four workouts a
+        week, one date night a month — and is a task carrying `progress_target`
+        greater than 1 OR `is_tracked` true. The flag exists so a target of one
+        can still be a quota rather than a deadline.
+
+        Quotas are never counted overdue and are excluded from the bulk snooze
+        sweep: "four times this week" cannot be late on a Tuesday. They do carry
+        a `due_at`, which is vestigial and read only by the iOS widget to draw
+        its pace tick — do not treat it as a promise.
+
+        Order is deliberately NOT specified here. Clients sort quotas
+        alphabetically so that logging progress on one never reorders the others
+        under the user's finger.
+      responses:
+        '200':
+          description: The user's open quotas
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      quotas:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Task'
+                      total:
+                        type: integer
+                      has_any:
+                        type: boolean
+                        description: |
+                          Whether the user has any quota at all, including done
+                          ones. Lets a client tell "none open" apart from "has
+                          never made one" when `quotas` is empty.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   # --- Reminders (§6) ---
 
   /api/reminders:

--- a/src/app/api/quotas/route.ts
+++ b/src/app/api/quotas/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Quotas surface API (REDESIGN-V03 §5)
+ *
+ * GET /api/quotas - Every open quota for the user
+ *
+ * The sibling of GET /api/reminders. A surface gets its own endpoint so it can
+ * be refreshed on every sync event without dragging the whole task list across
+ * the network — a quota's +1 emits a sync event, so this is on the hot path for
+ * the one gesture the surface exists for.
+ *
+ * Order is deliberately the client's: `trackedItems()` sorts quotas
+ * alphabetically so a count changing never moves a row under the user's finger,
+ * and the dashboard's Track panel renders the same eight things through the same
+ * function. One sort, one source of truth.
+ */
+
+import { NextRequest } from 'next/server'
+import { requireAuth, AuthError } from '@/core/auth'
+import { success, unauthorized, handleError } from '@/lib/api-response'
+import { getQuotas, hasAnyQuotas } from '@/core/tasks/quotas'
+import { formatTaskResponse } from '@/lib/format-task'
+import { log } from '@/lib/logger'
+import { withLogging } from '@/lib/with-logging'
+
+export const GET = withLogging(async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request)
+    const quotas = getQuotas(user.id)
+
+    return success({
+      quotas: quotas.map(formatTaskResponse),
+      total: quotas.length,
+      // Nothing renders this directly — it only picks which empty state the
+      // surface shows. Same contract as `has_any` on /api/reminders.
+      has_any: hasAnyQuotas(user.id),
+    })
+  } catch (err) {
+    if (err instanceof AuthError) return unauthorized(err.message)
+    log.error('api', 'GET /api/quotas error:', err)
+    return handleError(err)
+  }
+})

--- a/src/app/api/tasks/bulk/snooze-overdue/route.ts
+++ b/src/app/api/tasks/bulk/snooze-overdue/route.ts
@@ -54,7 +54,8 @@ export const POST = withLogging(async function POST(request: NextRequest) {
     // freezes once the daily sweep stops, so the old `due_at < now` SQL would
     // sweep items that aren't scheduled today — re-dating them and deepening
     // exactly the mess this redesign is unwinding.
-    const taskIds = getCurrentlyDueTaskIds(user.id)
+    const dueNow = getCurrentlyDueTaskIds(user.id)
+    const taskIds = [...dueNow]
 
     // Merge in explicitly included task IDs (e.g., the P4 task the user is acting on)
     const includeTaskIds = input.include_task_ids
@@ -87,10 +88,26 @@ export const POST = withLogging(async function POST(request: NextRequest) {
 
     // Dismiss only the tasks that were actually snoozed, not tasks that were
     // skipped by priority filtering (P4 Urgent may still be overdue).
+    //
+    // PERF (2026-09-06): this used to walk `getCurrentlyDueTaskIds()` a second
+    // time and diff, and `dismissNotificationsForTasks` then walked it a THIRD
+    // time for the badge. Each walk evaluates an rrule per recurring task —
+    // measured at 69ms on Trent's 512-task/193-recurring account, so ~208ms of
+    // the request was the same question asked three times. `bulkSnooze` already
+    // knows exactly which ids it moved, and the surviving overdue count follows
+    // from arithmetic: everything snoozed went to `until`, which is in the
+    // future, so what stays due is precisely what was due and did not move.
     if (result.tasksAffected > 0) {
-      const stillOverdueIds = new Set(getCurrentlyDueTaskIds(user.id))
-      const snoozedIds = taskIds.filter((id) => !stillOverdueIds.has(id))
-      dismissNotificationsForTasks(user.id, snoozedIds)
+      // The arithmetic only holds while `until` is genuinely in the future.
+      // bulkSnooze deliberately permits a past target ("tasks will just appear
+      // overdue immediately"), and in that case a snoozed task is still due —
+      // so fall back to measuring rather than report a badge that is too low.
+      const untilIsFuture = new Date(until).getTime() > Date.now()
+      const snoozedSet = new Set(result.snoozedIds)
+      const stillOverdue = untilIsFuture
+        ? dueNow.filter((id) => !snoozedSet.has(id)).length
+        : undefined
+      dismissNotificationsForTasks(user.id, result.snoozedIds, stillOverdue)
     }
 
     notifyDemoEngagement(user.name, 'update')

--- a/src/components/QuotasView.tsx
+++ b/src/components/QuotasView.tsx
@@ -60,13 +60,17 @@ export function QuotasView({
 
   const refresh = useCallback(async () => {
     try {
-      const res = await fetch('/api/tasks?done=false&limit=1000')
-      if (!res.ok) throw new Error(`GET /api/tasks ${res.status}`)
+      // This surface's OWN endpoint, the way Reminders has one. It used to ask
+      // for `/api/tasks?done=false&limit=1000` and filter in the browser: 512
+      // tasks over the wire to render eight, on every sync event — and a +1
+      // emits a sync event, so the phone paid it for every tap.
+      const res = await fetch('/api/quotas')
+      if (!res.ok) throw new Error(`GET /api/quotas ${res.status}`)
       const body = await res.json()
-      // trackedItems, not a raw filter: the dashboard sorts quotas by title so
-      // the order cannot jump as counts change (commit 9bcf03d, "frozen
-      // order"), and the two views of the same eight things must agree.
-      setTasks(trackedItems(body.data.tasks as Task[]))
+      // Still trackedItems, not the server's order: the dashboard sorts quotas
+      // by title so the order cannot jump as counts change (commit 9bcf03d,
+      // "frozen order"), and the two views of the same eight things must agree.
+      setTasks(trackedItems(body.data.quotas as Task[]))
       setError(null)
     } catch (err) {
       log.error('ui', 'Loading quotas failed:', err)

--- a/src/core/notifications/dismiss.ts
+++ b/src/core/notifications/dismiss.ts
@@ -41,16 +41,24 @@ export function getOverdueCount(userId: number): number {
  * Fire-and-forget — errors are logged but never thrown.
  * Called by dismissNotificationsForTasks and directly by undo/redo routes.
  */
-export function syncBadgeCount(userId: number): void {
+export function syncBadgeCount(userId: number, knownCount?: number): void {
   if (!isApnsConfigured()) return
-  const badgeCount = getOverdueCount(userId)
+  // `knownCount` lets a caller that has ALREADY established the post-change
+  // overdue count hand it over instead of paying for another
+  // `countCurrentlyDue()` — which evaluates an rrule for every recurring task.
+  // Only pass it when the number is exact; everyone else measures.
+  const badgeCount = knownCount ?? getOverdueCount(userId)
   log.info('notifications', `Badge update for user ${userId}: ${badgeCount} overdue`)
   sendApnsBadgeUpdate(userId, badgeCount)
     .then(() => log.info('notifications', `Badge update sent for user ${userId}: ${badgeCount}`))
     .catch((err) => log.error('notifications', 'Badge update error:', err))
 }
 
-export function dismissNotificationsForTasks(userId: number, taskIds: number[]): void {
+export function dismissNotificationsForTasks(
+  userId: number,
+  taskIds: number[],
+  knownOverdueCount?: number,
+): void {
   if (taskIds.length === 0) return
   log.info('notifications', `Dismiss requested for tasks [${taskIds.join(',')}] user ${userId}`)
   dismissTaskNotifications(userId, taskIds)
@@ -60,7 +68,7 @@ export function dismissNotificationsForTasks(userId: number, taskIds: number[]):
     .then(() => log.info('notifications', `APNs dismiss sent for tasks [${taskIds.join(',')}]`))
     .catch((err) => log.error('notifications', 'APNs dismiss error:', err))
 
-  syncBadgeCount(userId)
+  syncBadgeCount(userId, knownOverdueCount)
 }
 
 /**

--- a/src/core/tasks/bulk.ts
+++ b/src/core/tasks/bulk.ts
@@ -244,6 +244,17 @@ export interface BulkSnoozeResult {
   /** §6: reminders excluded because they are bucket-locked. */
   reminderSkipped: number
   noDueDateSkipped: number
+  /**
+   * The ids actually moved, in the order they were snoozed.
+   *
+   * The caller used to recover this by walking `getCurrentlyDueTaskIds()` a
+   * second time and diffing — an rrule evaluation over every recurring task
+   * (~70ms on a 512-task account) to learn something this function already
+   * knew. It is also the more truthful answer: the diff inferred "snoozed"
+   * from "no longer due", which is only the same thing as long as nothing else
+   * changes a due date in between.
+   */
+  snoozedIds: number[]
 }
 
 /**
@@ -265,6 +276,7 @@ export function bulkSnooze(options: BulkSnoozeOptions): BulkSnoozeResult {
       urgentSkipped: 0,
       reminderSkipped: 0,
       noDueDateSkipped: 0,
+      snoozedIds: [],
     }
   }
 
@@ -314,6 +326,7 @@ export function bulkSnooze(options: BulkSnoozeOptions): BulkSnoozeResult {
       urgentSkipped,
       reminderSkipped,
       noDueDateSkipped,
+      snoozedIds: [],
     }
   }
 
@@ -404,6 +417,7 @@ export function bulkSnooze(options: BulkSnoozeOptions): BulkSnoozeResult {
       urgentSkipped,
       reminderSkipped,
       noDueDateSkipped,
+      snoozedIds: snoozeable.map((t) => t.id),
     }
   })
 

--- a/src/core/tasks/quotas.ts
+++ b/src/core/tasks/quotas.ts
@@ -1,0 +1,53 @@
+/**
+ * Quotas surface queries (REDESIGN-V03 §5)
+ *
+ * A quota is "how often", not "when": four workouts a week, one date night a
+ * month. It is a task row carrying `progress_target > 1` OR `is_tracked = 1` —
+ * the flag exists so a target of one ("date night, once a month") can still be
+ * a quota rather than a deadline.
+ *
+ * This module is the sibling of `reminders.ts`, and exists for the same reason
+ * that one does: the surface needs ITS items, not everybody's. Before it, the
+ * Quotas page fetched `/api/tasks?done=false&limit=1000` and filtered in the
+ * browser — on Trent's account that is 512 tasks pulled over the wire to render
+ * eight, on every sync event, and a +1 emits a sync event. The phone paid that
+ * for every tap.
+ */
+
+import { getDb } from '@/core/db'
+import { isTracked } from '@/lib/track'
+import type { Task } from '@/types'
+import { getTasks } from './create'
+
+/**
+ * Every open quota for a user.
+ *
+ * Deliberately NOT ordered here. `trackedItems()` in `@/lib/slot-view` owns
+ * quota order — alphabetical, so logging on one never reorders the others under
+ * the user's finger (commit 9bcf03d, "frozen order") — and the dashboard's
+ * Track panel already sorts through it. Ordering here too would give the two
+ * views of the same eight things two different sources of truth, and SQLite's
+ * `COLLATE NOCASE` and JS's `localeCompare` do not agree on accented titles.
+ */
+export function getQuotas(userId: number): Task[] {
+  return getTasks({ userId, done: false, limit: 1000 }).filter(isTracked)
+}
+
+/**
+ * Whether the user has any quota at all, including done ones.
+ *
+ * Only the empty state reads this: it picks between "you have none yet, here is
+ * what they are for" and "nothing open right now". Mirrors `hasAnyReminders`.
+ */
+export function hasAnyQuotas(userId: number): boolean {
+  const row = getDb()
+    .prepare(
+      `SELECT 1 FROM tasks
+        WHERE user_id = ?
+          AND deleted_at IS NULL
+          AND (progress_target > 1 OR is_tracked = 1)
+        LIMIT 1`,
+    )
+    .get(userId)
+  return row !== undefined
+}

--- a/tests/behavioral/bo-bulk.test.ts
+++ b/tests/behavioral/bo-bulk.test.ts
@@ -431,6 +431,60 @@ describe('Bulk Snooze Relative Mode', () => {
   })
 
   /**
+   * BS-002b: the result names exactly which ids moved.
+   *
+   * The snooze-overdue route relies on this instead of walking
+   * `getCurrentlyDueTaskIds()` a second time and diffing — a per-recurring-task
+   * rrule evaluation to recover something bulkSnooze already knew. If this
+   * contract silently drops back to an empty array the route stops dismissing
+   * notifications at all, which is invisible in the response body.
+   */
+  test('BS-002b: snoozedIds names the tasks that actually moved, and excludes the skipped', () => {
+    const moved = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Ordinary task', due_at: localTime(9, 0), priority: 1 },
+    })
+    // P4 Urgent is excluded from a bulk sweep, so it must not appear.
+    const urgent = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Urgent task', due_at: localTime(9, 0), priority: 4 },
+    })
+
+    const result = bulkSnooze({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskIds: [moved.id, urgent.id],
+      deltaMinutes: 60,
+    })
+
+    expect(result.tasksAffected).toBe(1)
+    expect(result.snoozedIds).toEqual([moved.id])
+    expect(result.snoozedIds).not.toContain(urgent.id)
+    expect(result.snoozedIds).toHaveLength(result.tasksAffected)
+  })
+
+  /** Nothing eligible means nothing claimed. */
+  test('BS-002c: snoozedIds is empty when every task is skipped', () => {
+    const urgent = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Only urgent', due_at: localTime(9, 0), priority: 4 },
+    })
+
+    const result = bulkSnooze({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskIds: [urgent.id],
+      deltaMinutes: 60,
+    })
+
+    expect(result.tasksAffected).toBe(0)
+    expect(result.snoozedIds).toEqual([])
+  })
+
+  /**
    * BS-003: Relative snooze skips tasks with null due_at
    */
   test('BS-003: Relative snooze skips tasks with null due_at', () => {

--- a/tests/integration/quotas.test.ts
+++ b/tests/integration/quotas.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Quotas surface API integration tests (REDESIGN-V03 §5)
+ *
+ * GET /api/quotas is the sibling of GET /api/reminders. It exists so the Quotas
+ * surface can refresh on every sync event without pulling the whole task list:
+ * a +1 emits a sync event, so this is the hot path for the gesture the surface
+ * exists for. These tests pin the narrowing — if the endpoint ever starts
+ * returning ordinary tasks the payload regression is silent in the UI, which
+ * renders the same eight rows either way.
+ */
+
+import { describe, test, expect, beforeEach } from 'vitest'
+import { apiFetch, apiAnon, resetTestData } from './helpers'
+
+describe('Quotas surface API', () => {
+  beforeEach(async () => {
+    await resetTestData()
+  })
+
+  test('GET requires auth', async () => {
+    const res = await apiAnon('/api/quotas')
+    expect(res.status).toBe(401)
+  })
+
+  test('returns quotas only — never ordinary tasks or reminders', async () => {
+    const quota = (
+      await (
+        await apiFetch('/api/tasks', {
+          method: 'POST',
+          body: { title: 'Workouts', progress_target: 4, rrule: 'FREQ=WEEKLY' },
+        })
+      ).json()
+    ).data
+    // A target of 1 is still a quota when the flag says so ("date night").
+    const flagged = (
+      await (
+        await apiFetch('/api/tasks', {
+          method: 'POST',
+          body: { title: 'Date night', is_tracked: true, rrule: 'FREQ=MONTHLY' },
+        })
+      ).json()
+    ).data
+    const plain = (
+      await (
+        await apiFetch('/api/tasks', {
+          method: 'POST',
+          body: { title: 'An ordinary task', due_at: new Date().toISOString() },
+        })
+      ).json()
+    ).data
+    const reminder = (
+      await (
+        await apiFetch('/api/tasks', {
+          method: 'POST',
+          body: { title: 'A reminder', is_reminder: true, rrule: 'FREQ=DAILY' },
+        })
+      ).json()
+    ).data
+
+    const res = await apiFetch('/api/quotas')
+    expect(res.status).toBe(200)
+    const data = (await res.json()).data
+
+    const ids = data.quotas.map((q: { id: number }) => q.id)
+    expect(ids).toContain(quota.id)
+    expect(ids).toContain(flagged.id)
+    expect(ids).not.toContain(plain.id)
+    expect(ids).not.toContain(reminder.id)
+    expect(data.total).toBe(ids.length)
+    expect(data.has_any).toBe(true)
+  })
+
+  test('every returned row really is tracked, and none are done', async () => {
+    await apiFetch('/api/tasks', {
+      method: 'POST',
+      body: { title: 'Reading', progress_target: 3, rrule: 'FREQ=WEEKLY' },
+    })
+
+    const res = await apiFetch('/api/quotas')
+    expect(res.status).toBe(200)
+    const data = (await res.json()).data
+    expect(data.quotas.length).toBeGreaterThan(0)
+
+    for (const q of data.quotas) {
+      expect(q.is_tracked === true || q.progress_target > 1).toBe(true)
+      expect(q.done).toBe(false)
+      expect(q.is_reminder).toBe(false)
+    }
+  })
+
+  test('a trashed quota drops out', async () => {
+    const created = (
+      await (
+        await apiFetch('/api/tasks', {
+          method: 'POST',
+          body: { title: 'Temporary quota', progress_target: 2, rrule: 'FREQ=WEEKLY' },
+        })
+      ).json()
+    ).data
+    const id = created.id
+
+    const before = (await (await apiFetch('/api/quotas')).json()).data
+    expect(before.quotas.map((q: { id: number }) => q.id)).toContain(id)
+
+    await apiFetch(`/api/tasks/${id}`, { method: 'DELETE' })
+
+    const after = (await (await apiFetch('/api/quotas')).json()).data
+    expect(after.quotas.map((q: { id: number }) => q.id)).not.toContain(id)
+  })
+})


### PR DESCRIPTION
Both measured before and after, not estimated.

## 1. `snooze-overdue`: 222ms → 141ms (36%)

`getCurrentlyDueTaskIds()` evaluates an rrule per recurring task — **69–74ms** on Trent's 512-task / 193-recurring account. One request asked it **three times**:

1. to find what to snooze,
2. again afterwards, to diff "still due" and recover *which ids moved*,
3. and a third time inside `dismissNotificationsForTasks` → `syncBadgeCount`, for the badge.

Fixes:
- **`bulkSnooze` now returns `snoozedIds`.** It always knew them; the caller re-derived them by subtraction. This is also *more* truthful — the diff inferred "snoozed" from "no longer due", which only coincide while nothing else moves a due date in between.
- **`syncBadgeCount` takes an optional already-established count.** Every other caller still measures.
- The surviving overdue count is then arithmetic. **Guarded:** a past `until` is explicitly allowed by `bulkSnooze` ("tasks will just appear overdue immediately"), and in that case it falls back to measuring rather than under-reporting the badge.

## 2. Quotas: 447 KB → 5.4 KB per +1 tap (83×)

The surface fetched `/api/tasks?done=false&limit=1000` and filtered client-side — 512 tasks over the wire to render seven, **on every sync event, and a +1 is a sync event**. Reminders has had its own endpoint all along; Quotas now has the sibling, `GET /api/quotas`.

Order stays the client's: `trackedItems()` sorts alphabetically so a changing count never moves a row under the user's finger, and the dashboard's Track panel renders the same items through the same function.

## What this does NOT fix — the multi-press

The logs say why, and it isn't speed:

- **18:30:00** — the cron delivered **eight separate task notifications**.
- **18:30:43** — three requests in two seconds. All landed, all `200`. The first snoozed 122 tasks; the other two found nothing to do (57ms, 44ms).

He's tapping through a *stack*, not retrying a slow button. The iOS handler does dismiss the rest — but only after `await`ing the round trip, so the other seven sit there meanwhile. That's an iOS change and needs his device to verify.

## Verification

- 1026 behavioral, 249 integration, E2E 60/60
- Measured against a throwaway copy of the dev DB (deleted afterwards); payload measured against the real dev snapshot
- Deployed to dev, probed at 1280 and 375 on the **demo** account (probe rows deleted): +1 works, refresh now calls `/api/quotas`, double-tap guard still holds, no console errors
- `openapi.yaml` documents the new endpoint