### PR TITLE
One modal shell and one selection bar, instead of two of each

### DIFF
--- a/src/components/DetailModalShell.tsx
+++ b/src/components/DetailModalShell.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useCallback, useState, type ReactNode, type RefObject } from 'react'
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet'
+import { UnsavedChangesDialog } from '@/components/UnsavedChangesDialog'
+import { useIsMobile } from '@/hooks/useIsMobile'
+
+/**
+ * The chrome every surface's Details wears: a dialog on a wide screen, a bottom
+ * sheet on a phone, and one guard against closing over unsaved edits.
+ *
+ * Reminders and Quotas had this twice, line for line, differing only in the
+ * description string — which is exactly the kind of divergence Trent called out
+ * on 2026-09-06 ("why are we deviating from the other panels?"). Anything that
+ * should be true of both editors is now true of both by construction: the sheet
+ * height, the dialog width, the hidden accessible name, the drag-to-dismiss
+ * that switches off once there are edits to lose.
+ *
+ * What stays with the caller is only what genuinely differs: which editor goes
+ * inside, and what it is called.
+ */
+export function DetailModalShell({
+  open,
+  title,
+  description,
+  isDirty,
+  dirtyRef,
+  onClose,
+  onSave,
+  children,
+}: {
+  open: boolean
+  /** Accessible name — "Quota", "New reminder", "Reminders". Never shown. */
+  title: string
+  /** Accessible description of what this editor changes. Never shown. */
+  description: string
+  /** Whether the editor holds unsaved edits. Drives the drag affordance. */
+  isDirty: boolean
+  /**
+   * The SAME fact as `isDirty`, carried by a ref the caller writes
+   * synchronously when the editor reports.
+   *
+   * Both are needed and neither is redundant. Radix hands a dismissal to
+   * whichever onOpenChange it last captured, so a guard reading state trails
+   * the editor's report by a render — an Escape pressed right after an edit
+   * reached a guard that still believed the editor was clean, which is the bug
+   * this ref was introduced to fix. Mirroring the prop into a ref inside an
+   * effect would reintroduce it, one render later.
+   */
+  dirtyRef: RefObject<boolean>
+  /** Close and discard. The shell asks first when there are edits to lose. */
+  onClose: () => void
+  /** Commit the editor's staged changes — the detail component's `saveRef`. */
+  onSave: () => Promise<void> | void
+  children: ReactNode
+}) {
+  const isMobile = useIsMobile()
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) return
+      if (dirtyRef.current) setShowCloseConfirm(true)
+      else onClose()
+    },
+    [dirtyRef, onClose],
+  )
+
+  const handleDiscardAndClose = useCallback(() => {
+    setShowCloseConfirm(false)
+    onClose()
+  }, [onClose])
+
+  const handleSaveAndClose = useCallback(async () => {
+    await onSave()
+    // A successful save closes the modal itself; a failed one leaves it open
+    // with the edits, and the confirmation has served its purpose either way.
+    setShowCloseConfirm(false)
+  }, [onSave])
+
+  const confirmDialog = (
+    <UnsavedChangesDialog
+      open={showCloseConfirm}
+      onOpenChange={setShowCloseConfirm}
+      onDiscard={handleDiscardAndClose}
+      onSave={handleSaveAndClose}
+    />
+  )
+
+  if (isMobile) {
+    return (
+      <>
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+          <SheetContent
+            side="bottom"
+            className="max-h-[92dvh] overflow-y-auto rounded-t-2xl"
+            showCloseButton={false}
+            draggable={!isDirty}
+          >
+            <VisuallyHidden>
+              <SheetTitle>{title}</SheetTitle>
+              <SheetDescription>{description}</SheetDescription>
+            </VisuallyHidden>
+            <div className="px-4 pb-2">{children}</div>
+          </SheetContent>
+        </Sheet>
+        {confirmDialog}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent
+          className="max-h-[90vh] w-[32rem] max-w-[calc(100%-2rem)] overflow-y-auto p-4"
+          showCloseButton={false}
+        >
+          <VisuallyHidden>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </VisuallyHidden>
+          <div className="min-w-0">{children}</div>
+        </DialogContent>
+      </Dialog>
+      {confirmDialog}
+    </>
+  )
+}

--- a/src/components/QuotaDetailModal.tsx
+++ b/src/components/QuotaDetailModal.tsx
@@ -1,12 +1,8 @@
 'use client'
 
 import { useCallback, useRef, useState } from 'react'
-import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
-import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet'
-import { UnsavedChangesDialog } from '@/components/UnsavedChangesDialog'
+import { DetailModalShell } from '@/components/DetailModalShell'
 import { QuotaDetail, type QuotaChanges, type QuotaCreateDraft } from '@/components/QuotaDetail'
-import { useIsMobile } from '@/hooks/useIsMobile'
 import { cn } from '@/lib/utils'
 import type { Task } from '@/types'
 
@@ -40,17 +36,15 @@ export function QuotaDetailModal({
   onDelete: (tasks: Task[]) => void
   onOpenPage: (taskId: number) => void
 }) {
-  const isMobile = useIsMobile()
   const [isDirty, setIsDirty] = useState(false)
-  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
   const saveRef = useRef<(() => Promise<void> | void) | null>(null)
   const single = tasks.length === 1 ? tasks[0] : null
   const creating = tasks.length === 0 && !!create
 
-  // Dirtiness through a ref, not state: Radix hands a dismissal to whichever
-  // onOpenChange it last captured, and a callback closing over state trails the
-  // editor's report by a render — an Escape right after an edit reached a guard
-  // that still believed the editor was clean. Same fix as ReminderDetailModal.
+  // The ref is written synchronously here, the state drives rendering. The
+  // dismissal guard reads the ref: a callback closing over state trails the
+  // editor's report by a render, and an Escape right after an edit used to
+  // reach a guard that still believed the editor was clean.
   const isDirtyRef = useRef(false)
   const handleDirtyChange = useCallback((dirty: boolean) => {
     isDirtyRef.current = dirty
@@ -76,19 +70,8 @@ export function QuotaDetailModal({
     [onCreate, onClose],
   )
 
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      if (nextOpen) return
-      if (isDirtyRef.current) setShowCloseConfirm(true)
-      else onClose()
-    },
-    [onClose],
-  )
-
-  const handleSaveAndClose = useCallback(async () => {
-    await saveRef.current?.()
-    setShowCloseConfirm(false)
-  }, [])
+  /** Commit whatever the editor has staged — used by the unsaved-changes guard. */
+  const handleCommit = useCallback(() => saveRef.current?.(), [])
 
   if (tasks.length === 0 && !creating) return null
 
@@ -130,55 +113,17 @@ export function QuotaDetailModal({
     </div>
   )
 
-  const confirmDialog = (
-    <UnsavedChangesDialog
-      open={showCloseConfirm}
-      onOpenChange={setShowCloseConfirm}
-      onDiscard={() => {
-        setShowCloseConfirm(false)
-        onClose()
-      }}
-      onSave={handleSaveAndClose}
-    />
-  )
-
-  if (isMobile) {
-    return (
-      <>
-        <Sheet open={open} onOpenChange={handleOpenChange}>
-          <SheetContent
-            side="bottom"
-            className="max-h-[92dvh] overflow-y-auto rounded-t-2xl"
-            showCloseButton={false}
-            draggable={!isDirty}
-          >
-            <VisuallyHidden>
-              <SheetTitle>{name}</SheetTitle>
-              <SheetDescription>Change how often this is counted</SheetDescription>
-            </VisuallyHidden>
-            <div className="px-4 pb-2">{panel}</div>
-          </SheetContent>
-        </Sheet>
-        {confirmDialog}
-      </>
-    )
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent
-          className="max-h-[90vh] w-[32rem] max-w-[calc(100%-2rem)] overflow-y-auto p-4"
-          showCloseButton={false}
-        >
-          <VisuallyHidden>
-            <DialogTitle>{name}</DialogTitle>
-            <DialogDescription>Change how often this is counted</DialogDescription>
-          </VisuallyHidden>
-          <div className="min-w-0">{panel}</div>
-        </DialogContent>
-      </Dialog>
-      {confirmDialog}
-    </>
+    <DetailModalShell
+      open={open}
+      title={name}
+      description="Change how often this is counted"
+      isDirty={isDirty}
+      dirtyRef={isDirtyRef}
+      onClose={onClose}
+      onSave={handleCommit}
+    >
+      {panel}
+    </DetailModalShell>
   )
 }

--- a/src/components/QuotasView.tsx
+++ b/src/components/QuotasView.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSyncStream } from '@/hooks/useSyncStream'
 import { useNavigationGuard } from '@/components/NavigationGuardProvider'
 import { useRouter } from 'next/navigation'
-import { Gauge, Minus, Plus, Trash2, X, Pencil } from 'lucide-react'
+import { Gauge, Minus, Plus, Trash2, Pencil } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { QuotaDetailModal } from '@/components/QuotaDetailModal'
 import type { QuotaChanges, QuotaCreateDraft } from '@/components/QuotaDetail'
@@ -14,6 +14,7 @@ import { trackSummary, groupByPeriod, periodShort } from '@/lib/track'
 import { trackedItems } from '@/lib/slot-view'
 import { showToast } from '@/lib/toast'
 import { log } from '@/lib/logger'
+import { SelectionBarShell } from '@/components/SelectionBarShell'
 import { cn, fromRowControl } from '@/lib/utils'
 import type { Task } from '@/types'
 
@@ -144,11 +145,15 @@ export function QuotasView({
   return (
     <section aria-label="Quotas" data-quotas-view className="space-y-3 pb-24">
       <div className="flex items-center justify-between gap-2 px-1">
-        <p className="text-muted-foreground text-sm">
+        {/* The page's h1, exactly as the Reminders headline is: this one line
+            is the surface's summary, so it is the heading rather than a
+            paragraph sitting where a heading should be. Same size and colour
+            as before — the change is semantic, not visual. */}
+        <h1 className="text-muted-foreground text-sm">
           {tasks.length === 0
             ? 'No quotas yet.'
             : `${tasks.length} quota${tasks.length === 1 ? '' : 's'}`}
-        </p>
+        </h1>
         <Button size="sm" onClick={() => setCreating({ title: '' })}>
           <Plus className="size-4" />
           New quota
@@ -400,7 +405,11 @@ function QuotaRow({
   )
 }
 
-/** The floating bar, the same shape and position the other surfaces use. */
+/**
+ * The Quotas surface's verbs inside the shared selection bar. Position, count,
+ * Clear and the double-click guard all live in `SelectionBarShell`, so this bar
+ * cannot drift from the Reminders and dashboard ones again.
+ */
 function QuotaSelectionBar({
   count,
   onEdit,
@@ -412,53 +421,27 @@ function QuotaSelectionBar({
   onClear: () => void
   onDelete: () => void
 }) {
-  if (count === 0) return null
   return (
-    <div
-      data-selection-sheet
-      data-quota-selection-bar
-      className="animate-slide-up fixed bottom-20 left-1/2 z-50 max-w-[calc(100vw-2rem)] -translate-x-1/2 md:bottom-6"
-      // A double-click on a row near the bottom: the first click selects and
-      // summons this bar over the row, so the second click lands here. The
-      // browser still counts it as the second click of one gesture, so it must
-      // not press whatever it fell on — it finishes what was meant and opens
-      // the editor. Straight from ReminderSelectionBar.
-      onClickCapture={(e) => {
-        if (e.detail < 2) return
-        e.preventDefault()
-        e.stopPropagation()
-        onEdit()
-      }}
+    <SelectionBarShell
+      count={count}
+      onClear={onClear}
+      onDoubleClickIntent={onEdit}
+      testAttr="data-quota-selection-bar"
     >
-      <div
-        className="bg-primary text-primary-foreground flex items-center gap-2 rounded-xl px-4 py-3 shadow-xl"
-        aria-live="polite"
+      <Button size="sm" variant="secondary" onClick={onEdit}>
+        <Pencil className="size-4" />
+        Details
+      </Button>
+      <Button
+        size="sm"
+        variant="secondary"
+        onClick={onDelete}
+        aria-label={count === 1 ? 'Move to Trash' : `Move ${count} quotas to Trash`}
+        className="bg-primary-foreground/10 text-primary-foreground hover:bg-destructive active:bg-destructive hover:text-white"
       >
-        {count > 1 && <span className="text-sm font-medium tabular-nums">{count} selected</span>}
-        <Button size="sm" variant="secondary" onClick={onEdit}>
-          <Pencil className="size-4" />
-          Details
-        </Button>
-        <Button
-          size="sm"
-          variant="secondary"
-          onClick={onDelete}
-          aria-label={count === 1 ? 'Move to Trash' : `Move ${count} quotas to Trash`}
-          className="hover:bg-destructive active:bg-destructive hover:text-white"
-        >
-          <Trash2 className="size-4" />
-        </Button>
-        <Button
-          size="sm"
-          variant="ghost"
-          onClick={onClear}
-          aria-label="Clear selection"
-          className="text-primary-foreground/60 hover:text-primary-foreground hover:bg-primary-foreground/10 ml-1"
-        >
-          <X className="size-4" />
-        </Button>
-      </div>
-    </div>
+        <Trash2 className="size-4" />
+      </Button>
+    </SelectionBarShell>
   )
 }
 

--- a/src/components/ReminderDetailModal.tsx
+++ b/src/components/ReminderDetailModal.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import { useCallback, useRef, useState } from 'react'
-import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
-import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet'
-import { UnsavedChangesDialog } from '@/components/UnsavedChangesDialog'
+import { DetailModalShell } from '@/components/DetailModalShell'
 import {
   ReminderDetail,
   type ReminderBulkChanges,
@@ -12,7 +9,6 @@ import {
 } from '@/components/ReminderDetail'
 import type { QuickActionPanelChanges } from '@/components/QuickActionPanel'
 import type { ReminderCreateInput } from '@/hooks/useReminders'
-import { useIsMobile } from '@/hooks/useIsMobile'
 import { cn } from '@/lib/utils'
 import type { TimeSlot } from '@/lib/time-slot-assign'
 import type { Task } from '@/types'
@@ -62,9 +58,7 @@ export function ReminderDetailModal({
   onDelete,
   onOpenPage,
 }: ReminderDetailModalProps) {
-  const isMobile = useIsMobile()
   const [isDirty, setIsDirty] = useState(false)
-  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
   const saveRef = useRef<(() => Promise<void> | void) | null>(null)
   const single = tasks.length === 1 ? tasks[0] : null
   const creating = tasks.length === 0 && !!create
@@ -77,6 +71,10 @@ export function ReminderDetailModal({
   // the staged edit was dropped without asking (seen in the full E2E run).
   // The ref is current the moment the editor reports; the state only paints
   // the stripe.
+  // The ref is written synchronously here, the state drives rendering. The
+  // dismissal guard reads the ref: a callback closing over state trails the
+  // editor's report by a render, and an Escape right after an edit used to
+  // reach a guard that still believed the editor was clean.
   const isDirtyRef = useRef(false)
   const handleDirtyChange = useCallback((dirty: boolean) => {
     isDirtyRef.current = dirty
@@ -108,26 +106,8 @@ export function ReminderDetailModal({
     [onCreate, onClose],
   )
 
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      if (nextOpen) return
-      if (isDirtyRef.current) setShowCloseConfirm(true)
-      else onClose()
-    },
-    [onClose],
-  )
-
-  const handleDiscardAndClose = useCallback(() => {
-    setShowCloseConfirm(false)
-    onClose()
-  }, [onClose])
-
-  const handleSaveAndClose = useCallback(async () => {
-    await saveRef.current?.()
-    // A successful save closes the modal itself; a failed one leaves it open
-    // with the edits, and the confirmation has served its purpose either way.
-    setShowCloseConfirm(false)
-  }, [])
+  /** Commit whatever the editor has staged — used by the unsaved-changes guard. */
+  const handleCommit = useCallback(() => saveRef.current?.(), [])
 
   if (tasks.length === 0 && !creating) return null
 
@@ -179,52 +159,17 @@ export function ReminderDetailModal({
     </div>
   )
 
-  const confirmDialog = (
-    <UnsavedChangesDialog
-      open={showCloseConfirm}
-      onOpenChange={setShowCloseConfirm}
-      onDiscard={handleDiscardAndClose}
-      onSave={handleSaveAndClose}
-    />
-  )
-
-  if (isMobile) {
-    return (
-      <>
-        <Sheet open={open} onOpenChange={handleOpenChange}>
-          <SheetContent
-            side="bottom"
-            className="max-h-[92dvh] overflow-y-auto rounded-t-2xl"
-            showCloseButton={false}
-            draggable={!isDirty}
-          >
-            <VisuallyHidden>
-              <SheetTitle>{name}</SheetTitle>
-              <SheetDescription>Change when this comes up</SheetDescription>
-            </VisuallyHidden>
-            <div className="px-4 pb-2">{panel}</div>
-          </SheetContent>
-        </Sheet>
-        {confirmDialog}
-      </>
-    )
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent
-          className="max-h-[90vh] w-[32rem] max-w-[calc(100%-2rem)] overflow-y-auto p-4"
-          showCloseButton={false}
-        >
-          <VisuallyHidden>
-            <DialogTitle>{name}</DialogTitle>
-            <DialogDescription>Change when this comes up</DialogDescription>
-          </VisuallyHidden>
-          <div className="min-w-0">{panel}</div>
-        </DialogContent>
-      </Dialog>
-      {confirmDialog}
-    </>
+    <DetailModalShell
+      open={open}
+      title={name}
+      description="Change when this comes up"
+      isDirty={isDirty}
+      dirtyRef={isDirtyRef}
+      onClose={onClose}
+      onSave={handleCommit}
+    >
+      {panel}
+    </DetailModalShell>
   )
 }

--- a/src/components/ReminderSelectionBar.tsx
+++ b/src/components/ReminderSelectionBar.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { CheckCheck, FileText, Trash2, X } from 'lucide-react'
+import { CheckCheck, FileText, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { SelectionBarShell } from '@/components/SelectionBarShell'
 
 /**
  * The floating action bar for a selection on the Reminders surface.
@@ -35,70 +36,34 @@ export function ReminderSelectionBar({
   onDelete,
   onClear,
 }: ReminderSelectionBarProps) {
-  if (selectedCount === 0) return null
-
   return (
-    <div
-      data-selection-sheet
-      className="animate-slide-up fixed bottom-20 left-1/2 z-50 max-w-[calc(100vw-2rem)] -translate-x-1/2 md:bottom-6"
-      // A double-click on a row near the bottom of the screen: the first
-      // click selects the row and summons this bar over it, so the second
-      // click lands here instead. The browser still counts it as the second
-      // click of one gesture (`detail`), so it must not press whichever
-      // button it fell on — the green one would consider the thought — and
-      // it finishes what the user meant: open the selected reminder.
-      onClickCapture={(e) => {
-        if (e.detail < 2) return
-        e.preventDefault()
-        e.stopPropagation()
-        onDetails?.()
-      }}
-    >
-      <div
-        className="bg-primary text-primary-foreground flex items-center gap-2 rounded-xl px-4 py-3 shadow-xl"
-        aria-live="polite"
+    <SelectionBarShell count={selectedCount} onClear={onClear} onDoubleClickIntent={onDetails}>
+      <Button
+        size="sm"
+        variant="secondary"
+        onClick={onConsidered}
+        className="bg-green-600 text-white hover:bg-green-700 active:bg-green-700"
       >
-        {selectedCount > 1 && (
-          <span className="mr-2 text-sm font-medium">{selectedCount} selected</span>
-        )}
+        <CheckCheck className="mr-1 size-4" />
+        Considered
+      </Button>
 
-        <Button
-          size="sm"
-          variant="secondary"
-          onClick={onConsidered}
-          className="bg-green-600 text-white hover:bg-green-700 active:bg-green-700"
-        >
-          <CheckCheck className="mr-1 size-4" />
-          Considered
+      {onDetails && (
+        <Button size="sm" variant="secondary" onClick={onDetails}>
+          <FileText className="mr-1 size-4" />
+          Details
         </Button>
+      )}
 
-        {onDetails && (
-          <Button size="sm" variant="secondary" onClick={onDetails}>
-            <FileText className="mr-1 size-4" />
-            Details
-          </Button>
-        )}
-
-        <Button
-          size="sm"
-          variant="secondary"
-          onClick={onDelete}
-          aria-label={selectedCount === 1 ? 'Move to Trash' : `Move ${selectedCount} to Trash`}
-          className="bg-primary-foreground/10 text-primary-foreground hover:bg-destructive active:bg-destructive hover:text-white"
-        >
-          <Trash2 className="size-4" />
-        </Button>
-
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onClear}
-          aria-label="Clear selection"
-          className="text-primary-foreground/60 hover:text-primary-foreground hover:bg-primary-foreground/10 active:bg-primary-foreground/10 ml-2"
-        >
-          <X className="size-4" />
-        </Button>
-      </div>
-    </div>
+      <Button
+        size="sm"
+        variant="secondary"
+        onClick={onDelete}
+        aria-label={selectedCount === 1 ? 'Move to Trash' : `Move ${selectedCount} to Trash`}
+        className="bg-primary-foreground/10 text-primary-foreground hover:bg-destructive active:bg-destructive hover:text-white"
+      >
+        <Trash2 className="size-4" />
+      </Button>
+    </SelectionBarShell>
   )
 }

--- a/src/components/SelectionBarShell.tsx
+++ b/src/components/SelectionBarShell.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { type ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+
+/**
+ * The floating bar that appears while rows are selected, on every surface that
+ * has a selection.
+ *
+ * Position, the black pill, the count, Clear, and the double-click guard are
+ * the same object everywhere by construction — the dashboard's bar is the
+ * original and the others are meant to BE it, not to resemble it (Trent,
+ * 2026-09-06: "why are we deviating from the other panels?"). Reminders and
+ * Quotas had each rebuilt it, and had already drifted apart in small ways
+ * nobody chose: one right-margined its count and the other made it tabular,
+ * one nudged Clear by 4px more than the other. Only the verbs differ, and the
+ * verbs are what `children` is for.
+ *
+ * `data-selection-sheet` is load-bearing beyond styling: the toast system
+ * watches for it and lifts toasts clear of the bar, so a surface that hand-rolls
+ * its own bar silently loses that.
+ */
+export function SelectionBarShell({
+  count,
+  onClear,
+  onDoubleClickIntent,
+  testAttr,
+  children,
+}: {
+  count: number
+  onClear: () => void
+  /**
+   * What a double-click landing on the bar should finish — normally "open the
+   * details". A double-click on a row near the bottom selects with the first
+   * click, which summons this bar OVER the row, so the second click lands here.
+   * The browser still counts it as the second click of one gesture, so it must
+   * not press whichever button it fell on (on Reminders that was the green
+   * "Considered") — it completes what the user meant instead.
+   */
+  onDoubleClickIntent?: () => void
+  /** Marks a specific surface's bar for tests, e.g. `data-quota-selection-bar`. */
+  testAttr?: string
+  /** The surface's verbs. Clear is supplied here and always sits last. */
+  children: ReactNode
+}) {
+  if (count === 0) return null
+
+  const attrs = testAttr ? { [testAttr]: '' } : {}
+
+  return (
+    <div
+      data-selection-sheet
+      {...attrs}
+      className="animate-slide-up fixed bottom-20 left-1/2 z-50 max-w-[calc(100vw-2rem)] -translate-x-1/2 md:bottom-6"
+      onClickCapture={(e) => {
+        if (e.detail < 2) return
+        e.preventDefault()
+        e.stopPropagation()
+        onDoubleClickIntent?.()
+      }}
+    >
+      <div
+        className="bg-primary text-primary-foreground flex items-center gap-2 rounded-xl px-4 py-3 shadow-xl"
+        aria-live="polite"
+      >
+        {count > 1 && (
+          <span className="mr-1 text-sm font-medium tabular-nums">{count} selected</span>
+        )}
+
+        {children}
+
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClear}
+          aria-label="Clear selection"
+          className="text-primary-foreground/60 hover:text-primary-foreground hover:bg-primary-foreground/10 active:bg-primary-foreground/10 ml-1"
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Your ruling on 2026-09-06 was that a surface built beside an existing one should **be** it, not resemble it. Reminders and Quotas had each rebuilt two pieces of shared chrome, and the copies had already drifted in ways nobody chose.

## `DetailModalShell`

The dialog-on-desktop / sheet-on-phone split, the hidden accessible name, the drag that switches off once there are edits to lose, and the unsaved-changes guard. The two modals held this **line for line**, differing only in one description string.

## `SelectionBarShell`

Position, the count, Clear, and the guard against a double-click that lands on the bar *because the first click summoned it over the row*.

The drift it removes — none of it deliberate:

| | Reminders | Quotas |
|---|---|---|
| count | `mr-2` | `tabular-nums` |
| Clear | `ml-2`, with `active:` | `ml-1`, without |
| Trash | `bg-primary-foreground/10` | no background |

They agree now because there is only one of them.

`data-selection-sheet` turns out to be load-bearing beyond styling: the toast system watches for it to lift toasts clear of the bar — the thing you asked for earlier. A hand-rolled bar silently loses that.

## Also

The Quotas count line is now the page's `<h1>` instead of a `<p>` sitting where the heading should be, matching the Reminders headline. Same size and colour — the change is semantic, so the page finally has a heading.

## One thing I nearly broke

My first version of the shell mirrored the `isDirty` prop into a ref inside an effect. That reintroduces **exactly** the bug the original ref was added to fix: Radix hands a dismissal to whichever `onOpenChange` it last captured, so a guard reading state trails the editor's report by a render, and an Escape pressed right after an edit meets a guard that still thinks the editor is clean.

The shell now takes the ref itself, written synchronously by the caller. Verified on dev by editing and pressing Escape immediately — the unsaved-changes dialog appears.

Recording it because the comment that caught it was one of ours, and it earned its keep.

## Verification

- 1026 behavioral, 249 integration, E2E 60/60
- 98 lint warnings, down from 99 (one fewer over-long function)
- Deployed to dev, checked at 1280 and 375: both selection bars, the bulk editor, the dirty guard, no console errors
- Probe rows deleted