### PR TITLE
feat(quotas): a quota is not a task — its own surfaces, no due date, no snooze

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -602,6 +602,12 @@ paths:
       summary: Snooze task
       operationId: snoozeTask
       tags: [Tasks]
+      description: |
+        Moves a task's `due_at`. Two populations refuse it with a 400, because
+        neither has a due date to move: reminders (§6), which stay in their time
+        slot until completed, and quotas (§5), which are counted within a period
+        rather than due on a day. The bulk snooze sweep skips both instead of
+        failing.
       requestBody:
         required: true
         content:
@@ -638,6 +644,8 @@ paths:
                           description:
                             type: string
                             nullable: true
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -938,10 +946,16 @@ paths:
         greater than 1 OR `is_tracked` true. The flag exists so a target of one
         can still be a quota rather than a deadline.
 
-        Quotas are never counted overdue and are excluded from the bulk snooze
-        sweep: "four times this week" cannot be late on a Tuesday. They do carry
-        a `due_at`, which is vestigial and read only by the iOS widget to draw
-        its pace tick — do not treat it as a promise.
+        A quota has NO due date (since 2026-09-08): `due_at` and
+        `original_due_at` are always null, creating or updating one with a date
+        is a 400, and snoozing one is a 400. "Four times this week" cannot be
+        late on a Tuesday. The period a quota counts within is named by its
+        rrule's FREQ; the current period's start is tracked server-side.
+
+        A quota is also absent from `GET /api/tasks`-backed list surfaces in the
+        app — it appears on this endpoint and in the Track panel and nowhere
+        else — but `GET /api/tasks` itself still returns quotas, so clients that
+        build their own Track view from the full corpus keep working.
 
         Order is deliberately NOT specified here. Clients sort quotas
         alphabetically so that logging progress on one never reorders the others

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -950,7 +950,9 @@ paths:
         `original_due_at` are always null, creating or updating one with a date
         is a 400, and snoozing one is a 400. "Four times this week" cannot be
         late on a Tuesday. The period a quota counts within is named by its
-        rrule's FREQ; the current period's start is tracked server-side.
+        rrule's FREQ, and the current period's start is `progress_period_start`
+        on the task — that field is the period anchor; use it, not `due_at`, for
+        pace.
 
         A quota is also absent from `GET /api/tasks`-backed list surfaces in the
         app — it appears on this endpoint and in the Track panel and nowhere
@@ -1827,6 +1829,17 @@ components:
             How many increments are logged this period. Reaching the target
             marks the task "met" but does NOT complete it; the task stays open
             until its period boundary, so overflow (3/2) remains observable.
+        progress_period_start:
+          type: string
+          format: date-time
+          nullable: true
+          description: >
+            A quota's period anchor (§5) - the UTC instant the current period
+            began, by the user's local calendar (Monday 00:00 for a week, the
+            1st for a month). Null until the period-rollover job first runs for
+            the quota, and null on anything that is not a quota. USE THIS, NOT
+            due_at, for anything that needs to know how far through its period a
+            quota is (a pace indicator, for example): a quota has no due_at.
         completion_count:
           type: integer
         snooze_count:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -709,9 +709,9 @@ paths:
           application/json:
             schema:
               type: object
-              required: [task_ids]
+              required: [ids]
               properties:
-                task_ids:
+                ids:
                   type: array
                   items:
                     type: integer
@@ -823,9 +823,9 @@ paths:
           application/json:
             schema:
               type: object
-              required: [task_ids, changes]
+              required: [ids, changes]
               properties:
-                task_ids:
+                ids:
                   type: array
                   items:
                     type: integer
@@ -876,9 +876,9 @@ paths:
           application/json:
             schema:
               type: object
-              required: [task_ids]
+              required: [ids]
               properties:
-                task_ids:
+                ids:
                   type: array
                   items:
                     type: integer

--- a/src/app/api/tasks/counts/route.ts
+++ b/src/app/api/tasks/counts/route.ts
@@ -14,17 +14,20 @@ import { success, unauthorized, handleError } from '@/lib/api-response'
 import { formatTasksResponse } from '@/lib/format-task'
 import { getTasks } from '@/core/tasks'
 import { countTasks } from '@/lib/task-counts'
+import { isTracked } from '@/lib/track'
 import { log } from '@/lib/logger'
 import { withLogging } from '@/lib/with-logging'
 
 export const GET = withLogging(async function GET(request: NextRequest) {
   try {
     const user = await requireAuth(request)
-    // Same query the Tasks page server-renders from, minus reminders — the
-    // page never counts those (§6: reminders are not debt), see the
-    // `visibleTasks` filter in DashboardClient.
+    // Same query the Tasks page server-renders from, minus the two populations
+    // that are not tasks: reminders (§6, not debt) and quotas (§5, counted
+    // within a period rather than due on a day). Both live on their own
+    // surfaces — see the `visibleTasks` filter in DashboardClient, which this
+    // has to agree with to the digit.
     const tasks = formatTasksResponse(getTasks({ userId: user.id, limit: 1000 })).filter(
-      (t) => !t.is_reminder,
+      (t) => !t.is_reminder && !isTracked(t),
     )
     return success(countTasks(tasks, user.timezone))
   } catch (err) {

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { TaskList, buildTaskGroups, sortTasks, type GroupingMode } from '@/components/TaskList'
 import { useTimeSlots } from '@/hooks/useTimeSlots'
 import { UNDATED_LABEL } from '@/lib/slot-view'
+import { isTracked } from '@/lib/track'
 import { publishTaskCounts } from '@/hooks/useTaskNavCounts'
 import { TrackPanel } from '@/components/TrackPanel'
 import { ViewModeToggle } from '@/components/ViewModeToggle'
@@ -607,19 +608,25 @@ function HomeContent({
   const [searchResults, setSearchResults] = useState<Task[]>([])
 
   /**
-   * §6/§7.3: the dashboard is tasks; reminders live on their own surface
-   * (`/reminders`, its own route and tab).
+   * §5/§6/§7.3: the dashboard is TASKS. Two populations are not tasks and are
+   * dropped here — reminders (§6), which live on `/reminders`, and quotas (§5),
+   * which live on `/quotas` and in the Track panel above this list.
    *
-   * Reminders are filtered out here rather than server-side so `/api/tasks`
-   * keeps returning the whole corpus for every other caller. Doing it at this
-   * one point also keeps them out of everything derived from the list —
-   * counts, the overdue badge, filters, keyboard order — which is exactly the
-   * §6 carve-out ("never counted in overdue, never in the badge") expressed in
-   * the client.
+   * "A quota is not a task. It appears on the Quotas page and in the Track
+   * panel and nowhere else" (Trent, 2026-09-08). It used to be a plain row in
+   * the All and Projects views wearing a "0 / 4" chip, which put a thing with
+   * no due date, no snooze and no Done in among things that have all three.
+   *
+   * Filtered in the client rather than server-side so `/api/tasks` keeps
+   * returning the whole corpus for every other caller — the Track panel below
+   * builds from that same fetch, and so does the iOS widget. Doing it at this
+   * one point keeps both populations out of everything derived from the list:
+   * the chip counts, "Showing N of M", the header counts, keyboard order,
+   * select-all and the clipboard.
    */
-  const visibleTasks = useMemo(() => tasks.filter((t) => !t.is_reminder), [tasks])
+  const visibleTasks = useMemo(() => tasks.filter((t) => !t.is_reminder && !isTracked(t)), [tasks])
   const visibleSearchResults = useMemo(
-    () => searchResults.filter((t) => !t.is_reminder),
+    () => searchResults.filter((t) => !t.is_reminder && !isTracked(t)),
     [searchResults],
   )
 
@@ -666,7 +673,13 @@ function HomeContent({
     if (!task && tasks.length === 0) return
     taskParamProcessed.current = true
     if (task) {
-      handleViewTask(task)
+      // §5: a quota does not open in the dashboard's QuickActionPanel — that
+      // panel is a due date and a snooze grid, neither of which a quota has.
+      // Its own editor is on the detail route, which already renders
+      // QuotaDetail for a tracked row. This is the last path by which a quota
+      // could still reach the panel now that it is out of every list.
+      if (isTracked(task)) router.push(`/tasks/${task.id}`)
+      else handleViewTask(task)
     }
     // Strip the param with a raw history rewrite, NOT router.replace: a router
     // navigation issues an RSC fetch, and if that fetch fails (WebKit does
@@ -1093,9 +1106,12 @@ function HomeContent({
   }, [tasks_, timezone])
 
   // Compute selected tasks for bulk operations
+  // Reads `visibleTasks`, not the raw corpus: the selection can only ever hold
+  // ids of rendered rows, and resolving it against rows this page deliberately
+  // hides would let a reminder or a quota reach the bulk action sheet.
   const selectedTasks = useMemo(() => {
-    return tasks.filter((t) => selection.selectedIds.has(t.id))
-  }, [tasks, selection.selectedIds])
+    return visibleTasks.filter((t) => selection.selectedIds.has(t.id))
+  }, [visibleTasks, selection.selectedIds])
 
   // Fetch tasks on initial mount (skipped when server provides initialTasks)
   const hasInitialData = initialTasks !== undefined
@@ -1171,6 +1187,7 @@ function HomeContent({
       <DashboardView
         tasks={tasks_}
         allTasks={baseTasks}
+        quotaSource={tasks}
         projects={projects}
         grouping={grouping}
         onGroupingChange={(next) => {
@@ -1320,6 +1337,7 @@ function HomeContent({
 function DashboardView({
   tasks,
   allTasks,
+  quotaSource,
   projects,
   grouping,
   onGroupingChange,
@@ -1430,6 +1448,12 @@ function DashboardView({
 }: {
   tasks: Task[]
   allTasks: Task[]
+  /**
+   * The unfiltered corpus, for the Track panel only. `allTasks` deliberately
+   * has quotas removed (they are not tasks, §5), and the panel is the one
+   * place on this page that needs them.
+   */
+  quotaSource: Task[]
   projects: Project[]
   grouping: GroupingMode
   onGroupingChange: (grouping: GroupingMode) => void
@@ -1734,8 +1758,10 @@ function DashboardView({
 
         {/* §5: the quotas' instrument panel — above the list on every view of
             the Tasks page ("wherever they go, it can't be buried"), unaffected
-            by list filters. Hidden while searching so results stay results. */}
-        {!searchQuery && <TrackPanel tasks={allTasks} />}
+            by list filters. Hidden while searching so results stay results.
+            Fed the UNFILTERED corpus, not `allTasks`: quotas are exactly what
+            `allTasks` now drops, so passing it would empty this panel. */}
+        {!searchQuery && <TrackPanel tasks={quotaSource} />}
 
         <TaskList
           tasks={tasks}

--- a/src/components/QuotaDetail.tsx
+++ b/src/components/QuotaDetail.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
 import { trackState, quotaFreqOf, quotaLabelOf, QUOTA_PERIODS, type QuotaFreq } from '@/lib/track'
+import { isReservedLabel } from '@/lib/label-vocabulary'
 import { useDomainLabels } from '@/hooks/useDomainLabels'
 import { useLabelConfig } from '@/components/PreferencesProvider'
 import { getLabelClasses } from '@/lib/label-colors'
@@ -378,17 +379,32 @@ function LabelField({
   // The current value is always offered, even when the registry has never
   // heard of it: a quota carrying a legacy label must be able to keep it, and
   // a name typed a moment ago must show as chosen before the registry reloads.
+  //
+  // Except a RESERVED one. `ai-*` labels are machinery — enrichment writes
+  // `ai-failed`, creation writes `ai-to-process` — and a quota that happens to
+  // carry one is not thereby filed under it. Offering it as a chip invited the
+  // user to hand-assign a processing state; `quotaLabelOf` skips them for the
+  // same reason, so such a quota reads as unlabelled here and "None" is what
+  // shows as chosen.
   const options = useMemo(() => {
-    const names = new Set(registered)
-    if (value) names.add(value)
+    const names = new Set(registered.filter((n) => !isReservedLabel(n)))
+    if (value && !isReservedLabel(value)) names.add(value)
     return [...names].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
   }, [registered, value])
 
   function commitDraft() {
-    const name = draft.trim()
+    const typed = draft.trim()
     setTyping(false)
     setDraft('')
-    if (name) onChange(name)
+    if (!typed) return
+    // Typing a name the registry already has in another case reuses ITS
+    // spelling rather than creating a variant. The registry's UNIQUE is
+    // case-sensitive, so "Kids" typed against an existing "kids" would become a
+    // second row, a second chip and — before `groupByLabel` started keying
+    // case-insensitively — a second group with an identical header. Fixing the
+    // grouping hides that; this stops making them.
+    const existing = registered.find((n) => n.toLowerCase() === typed.toLowerCase())
+    onChange(existing ?? typed)
   }
 
   return (

--- a/src/components/QuotaDetail.tsx
+++ b/src/components/QuotaDetail.tsx
@@ -5,7 +5,10 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
-import { trackState, quotaFreqOf, QUOTA_PERIODS, type QuotaFreq } from '@/lib/track'
+import { trackState, quotaFreqOf, quotaLabelOf, QUOTA_PERIODS, type QuotaFreq } from '@/lib/track'
+import { useDomainLabels } from '@/hooks/useDomainLabels'
+import { useLabelConfig } from '@/components/PreferencesProvider'
+import { getLabelClasses } from '@/lib/label-colors'
 import type { Task } from '@/types'
 
 /**
@@ -37,6 +40,14 @@ import type { Task } from '@/types'
  */
 type QuotaPeriod = QuotaFreq
 
+/**
+ * The label being edited. THREE states, and they are all different things:
+ * a name, `null` for "no label", and `undefined` for "the selection disagrees".
+ * Collapsing the last two would make it impossible to clear the label off a
+ * mixed selection — the same trap the nullable `period` above documents.
+ */
+type QuotaLabelChoice = string | null | undefined
+
 export interface QuotaCreateDraft {
   title: string
 }
@@ -48,6 +59,10 @@ export interface QuotaChanges {
   progress_target?: number
   is_tracked?: true
   rrule?: string
+  /** Always zero or one entry — a quota has ONE label (§5, Trent 2026-09-08). */
+  labels?: string[]
+  /** §7.2's opt-in: register a name the registry has never seen, in this write. */
+  create_label?: true
 }
 
 export interface QuotaDetailProps {
@@ -84,32 +99,20 @@ export function QuotaDetail({
   const single = tasks.length === 1 ? tasks[0] : null
 
   /** What the selection agrees on; '' / null where it does not. */
-  const base = useMemo(() => {
-    if (creating)
-      return {
-        title: create?.title ?? '',
-        target: '3',
-        period: 'WEEKLY' as QuotaPeriod | null,
-        notes: '',
-        allPeriodless: false,
-      }
-    const targets = new Set(tasks.map((t) => String(Math.max(1, t.progress_target ?? 1))))
-    const periods = new Set(tasks.map((t) => quotaFreqOf(t.rrule)))
-    return {
-      title: single?.title ?? '',
-      target: targets.size === 1 ? [...targets][0] : '',
-      period: periods.size === 1 ? [...periods][0] : null,
-      notes: single?.notes ?? '',
-      // Every selected quota genuinely has no period, as opposed to the
-      // selection disagreeing about which one it is.
-      allPeriodless: periods.size === 1 && [...periods][0] === null,
-    }
-  }, [creating, create, tasks, single])
+  const base = useMemo(
+    () => describeBase({ creating, create, tasks, single }),
+    [creating, create, tasks, single],
+  )
 
   const [title, setTitle] = useState(base.title)
   const [target, setTarget] = useState(base.target)
   const [period, setPeriod] = useState<QuotaPeriod | null>(base.period)
+  const [label, setLabel] = useState<QuotaLabelChoice>(base.label)
   const [notes, setNotes] = useState(base.notes)
+
+  // The registry is the option list. `reload` runs after a save that registered
+  // a new name, so the next quota edited in the same session is offered it.
+  const { labels: registeredLabels, reload: reloadLabels } = useDomainLabels()
 
   const {
     targetNumber,
@@ -117,10 +120,11 @@ export function QuotaDetail({
     notesTouched,
     targetTouched,
     periodTouched,
+    labelTouched,
     dirty,
     targetOk,
     canSave,
-  } = describeDraft({ creating, base, title, target, period, notes })
+  } = describeDraft({ creating, base, title, target, period, label, notes })
 
   // Report dirtiness, and report clean on the way out: the modal unmounts this
   // when it closes, and without the unmount clear the host stayed "dirty" until
@@ -161,6 +165,18 @@ export function QuotaDetail({
       changes.is_tracked = true
       if (period !== null) changes.rrule = `FREQ=${period}`
     }
+    // The label goes ONLY when it was actually chosen, for the same reason the
+    // rule does: six quotas on this corpus still carry TWO labels from before
+    // one-label-per-quota, and the migration deliberately left them alone.
+    // Editing such a quota's target must not quietly drop its second label —
+    // but choosing a label does, which is the point of the rule.
+    if (labelTouched && label !== undefined) {
+      changes.labels = label ? [label] : []
+      // §7.2: an unknown label is refused unless the write says to create it.
+      // This is the flag the API documents for exactly this case, rather than
+      // a separate round-trip to the registry endpoint.
+      if (label && !registeredLabels.includes(label)) changes.create_label = true
+    }
     return changes
   }, [
     creating,
@@ -168,10 +184,13 @@ export function QuotaDetail({
     notesTouched,
     targetTouched,
     periodTouched,
+    labelTouched,
     title,
     notes,
     targetNumber,
     period,
+    label,
+    registeredLabels,
   ])
 
   const [saving, setSaving] = useState(false)
@@ -186,6 +205,8 @@ export function QuotaDetail({
       const changes = buildChanges()
       if (creating) await onCreate?.(changes)
       else await onSave?.(changes)
+      // The write just minted a label; the option list is now one short.
+      if (changes.create_label) reloadLabels()
       // Adopt what was actually SENT, not what was typed. The request trims,
       // so a stray trailing space left `base` and the field disagreeing
       // forever: a fully saved quota kept its blue stripe and kept raising the
@@ -200,7 +221,7 @@ export function QuotaDetail({
     } finally {
       setSaving(false)
     }
-  }, [canSave, saving, buildChanges, creating, onCreate, onSave])
+  }, [canSave, saving, buildChanges, creating, onCreate, onSave, reloadLabels])
 
   useEffect(() => {
     if (!saveRef) return
@@ -214,6 +235,7 @@ export function QuotaDetail({
     setTitle(base.title)
     setTarget(base.target)
     setPeriod(base.period)
+    setLabel(base.label)
     setNotes(base.notes)
   }
 
@@ -242,6 +264,8 @@ export function QuotaDetail({
         onPeriodChange={setPeriod}
         showError={targetTouched && !targetOk}
       />
+
+      <LabelField value={label} onChange={setLabel} registered={registeredLabels} />
 
       {(creating || single) && <NotesField value={notes} onChange={setNotes} />}
 
@@ -314,6 +338,144 @@ function CadenceField({
         <p className="text-destructive text-xs">A target is a whole number from 1 to 1000.</p>
       )}
     </fieldset>
+  )
+}
+
+/**
+ * The quota's ONE label — the grouping the Quotas page reads.
+ *
+ * Trent, 2026-09-08: "I think we need to have one label for quotas… there's a
+ * bunch of stuff for the kids and there are other things." So this is
+ * single-select, not the task editor's multi-label chip bar: picking a second
+ * label replaces the first rather than adding to it, because the page files
+ * each quota in exactly one place.
+ *
+ * Options are the DOMAIN facet of the label registry (§7.2) — the `ai-*`
+ * operational labels are machinery and are never offered. "None" is a real
+ * choice and sits first. A name that is not in the registry can be typed, and
+ * is registered by the save itself (`create_label`); it is added to the chips
+ * immediately so the pressed state has something to be pressed on.
+ *
+ * Chips rather than a select, matching `CadenceField` directly above it: this
+ * editor's whole vocabulary is chips, and a thirteen-label registry wraps into
+ * two lines. Colours come from `label_config` through `getLabelClasses`, the
+ * same call the filter bar and the task editor make, so a label looks the same
+ * everywhere it appears.
+ */
+function LabelField({
+  value,
+  onChange,
+  registered,
+}: {
+  value: QuotaLabelChoice
+  onChange: (value: string | null) => void
+  registered: string[]
+}) {
+  const { labelConfig } = useLabelConfig()
+  const [typing, setTyping] = useState(false)
+  const [draft, setDraft] = useState('')
+
+  // The current value is always offered, even when the registry has never
+  // heard of it: a quota carrying a legacy label must be able to keep it, and
+  // a name typed a moment ago must show as chosen before the registry reloads.
+  const options = useMemo(() => {
+    const names = new Set(registered)
+    if (value) names.add(value)
+    return [...names].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+  }, [registered, value])
+
+  function commitDraft() {
+    const name = draft.trim()
+    setTyping(false)
+    setDraft('')
+    if (name) onChange(name)
+  }
+
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm font-medium">Label</legend>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {/* Mixed selection: nothing is pressed, and the em dash says why —
+            the same mark the task panel uses for a mixed field. */}
+        {value === undefined && <span className="text-muted-foreground text-sm">—</span>}
+        <LabelChip
+          name="None"
+          pressed={value === null}
+          onClick={() => onChange(null)}
+          testValue="none"
+        />
+        {options.map((name) => (
+          <LabelChip
+            key={name}
+            name={name}
+            pressed={value === name}
+            onClick={() => onChange(name)}
+            colorClasses={getLabelClasses(name, labelConfig)}
+            testValue={name}
+          />
+        ))}
+        {typing ? (
+          <Input
+            aria-label="New label"
+            autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            // Blur commits rather than cancels: on a phone, "type the name then
+            // reach for Save" is the ordinary gesture, and throwing the name
+            // away at that moment would look like the field ignoring the user.
+            // Escape is the way out, and it is the only way out.
+            onBlur={commitDraft}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                commitDraft()
+              }
+              if (e.key === 'Escape') {
+                setTyping(false)
+                setDraft('')
+              }
+            }}
+            placeholder="New label"
+            className="h-8 w-32 text-[16px]"
+          />
+        ) : (
+          <LabelChip name="+ New" pressed={false} onClick={() => setTyping(true)} testValue="new" />
+        )}
+      </div>
+    </fieldset>
+  )
+}
+
+function LabelChip({
+  name,
+  pressed,
+  onClick,
+  colorClasses,
+  testValue,
+}: {
+  name: string
+  pressed: boolean
+  onClick: () => void
+  colorClasses?: string | null
+  testValue: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={pressed}
+      data-quota-label-chip={testValue}
+      className={cn(
+        'rounded-full border px-3 py-1 text-sm transition-colors',
+        pressed
+          ? 'border-foreground bg-foreground text-background'
+          : colorClasses
+            ? `${colorClasses} border-current/20`
+            : 'hover:border-foreground/40',
+      )}
+    >
+      {name}
+    </button>
   )
 }
 
@@ -393,6 +555,58 @@ function QuotaActions({
 }
 
 /**
+ * What the editor OPENS on: the stored state, reduced across the selection.
+ *
+ * Every field has to answer three things rather than two — a shared value, a
+ * shared absence, and disagreement — and it is the middle one that keeps
+ * getting lost: a period-less quota once read back as weekly, so editing its
+ * target rewrote its schedule. `null` therefore means "genuinely none" and is
+ * a real answer; only `undefined` (label) or an empty string (target) means
+ * "they differ, do not touch this".
+ *
+ * Module-level and pure, next to `describeDraft`, which does the same job for
+ * the edited half — the component stays layout plus state.
+ */
+function describeBase({
+  creating,
+  create,
+  tasks,
+  single,
+}: {
+  creating: boolean
+  create?: QuotaCreateDraft | null
+  tasks: Task[]
+  single: Task | null
+}) {
+  if (creating)
+    return {
+      title: create?.title ?? '',
+      target: '3',
+      period: 'WEEKLY' as QuotaPeriod | null,
+      // A new quota starts unlabelled — `null`, not `undefined`: nothing is in
+      // disagreement, the answer is simply "none".
+      label: null as QuotaLabelChoice,
+      notes: '',
+      allPeriodless: false,
+    }
+  const targets = new Set(tasks.map((t) => String(Math.max(1, t.progress_target ?? 1))))
+  const periods = new Set(tasks.map((t) => quotaFreqOf(t.rrule)))
+  const labels = new Set(tasks.map(quotaLabelOf))
+  return {
+    title: single?.title ?? '',
+    target: targets.size === 1 ? [...targets][0] : '',
+    period: periods.size === 1 ? [...periods][0] : null,
+    // One agreed label (or one agreed "none"); `undefined` when they differ, so
+    // picking "None" on a mixed selection still reads as a change.
+    label: (labels.size === 1 ? [...labels][0] : undefined) as QuotaLabelChoice,
+    notes: single?.notes ?? '',
+    // Every selected quota genuinely has no period, as opposed to the selection
+    // disagreeing about which one it is.
+    allPeriodless: periods.size === 1 && [...periods][0] === null,
+  }
+}
+
+/**
  * What the draft is, and whether it can be saved — pulled out of the component
  * because it is nearly all of its branching.
  *
@@ -408,6 +622,7 @@ function describeDraft({
   title,
   target,
   period,
+  label,
   notes,
 }: {
   creating: boolean
@@ -415,12 +630,14 @@ function describeDraft({
     title: string
     target: string
     period: QuotaPeriod | null
+    label: QuotaLabelChoice
     notes: string
     allPeriodless: boolean
   }
   title: string
   target: string
   period: QuotaPeriod | null
+  label: QuotaLabelChoice
   notes: string
 }) {
   const targetNumber = Number.parseInt(target, 10)
@@ -428,7 +645,8 @@ function describeDraft({
   const periodTouched = period !== base.period
   const titleTouched = title !== base.title
   const notesTouched = notes !== base.notes
-  const dirty = titleTouched || notesTouched || targetTouched || periodTouched
+  const labelTouched = label !== base.label
+  const dirty = titleTouched || notesTouched || targetTouched || periodTouched || labelTouched
   const targetOk = target.length > 0 && targetNumber >= 1 && targetNumber <= 1000
   // Creating needs a title, a valid target and a period. Editing needs only
   // what is being changed to be valid — a period-less quota, and a selection
@@ -443,6 +661,7 @@ function describeDraft({
     notesTouched,
     targetTouched,
     periodTouched,
+    labelTouched,
     dirty,
     targetOk,
     canSave,

--- a/src/components/QuotaDetail.tsx
+++ b/src/components/QuotaDetail.tsx
@@ -23,8 +23,9 @@ import type { Task } from '@/types'
  * left alone stays per-quota, and a period the selection disagrees about shows
  * nothing pressed until one is chosen.
  *
- * The `due_at` these rows still carry is deliberately untouched — the iOS Track
- * widget reads it for its pace tick (`TrackWidget.elapsedFraction`).
+ * A quota carries no `due_at` at all since 2026-09-08 (§5, Trent: "a quota is
+ * not a task"): the server refuses to stamp one, refuses to accept one, and
+ * the startup migration cleared the stale dates these rows used to hold.
  */
 
 /**
@@ -148,9 +149,9 @@ export function QuotaDetail({
     //
     // Sending it on any schedule edit flattened whatever else the rule carried:
     // a quota on FREQ=WEEKLY;INTERVAL=2 silently became every week, and a BYDAY
-    // was dropped — and because the rrule then differed, the server re-derived
-    // anchors and recomputed `due_at`, the one field this editor promises not
-    // to touch because the iOS widget's pace tick reads it.
+    // was dropped. (It also made the server re-derive anchors and recompute a
+    // `due_at` behind the editor's back — that half is now fixed at the source:
+    // a tracked row never gets a computed date.)
     //
     // It also means a quota with NO period, and a selection that disagrees
     // about its period, can both have their target edited while each keeps its

--- a/src/components/QuotasView.tsx
+++ b/src/components/QuotasView.tsx
@@ -10,8 +10,10 @@ import { QuotaDetailModal } from '@/components/QuotaDetailModal'
 import type { QuotaChanges, QuotaCreateDraft } from '@/components/QuotaDetail'
 import { useTrackProgress } from '@/hooks/useTrackProgress'
 import { useSelectionMode } from '@/hooks/useSelectionMode'
-import { trackSummary, groupByPeriod, periodShort } from '@/lib/track'
+import { quotaGroupSummary, groupByLabel, periodLabel, periodShort } from '@/lib/track'
 import { trackedItems } from '@/lib/slot-view'
+import { useLabelConfig } from '@/components/PreferencesProvider'
+import { getLabelClasses } from '@/lib/label-colors'
 import { showToast } from '@/lib/toast'
 import { log } from '@/lib/logger'
 import { SelectionBarShell } from '@/components/SelectionBarShell'
@@ -31,10 +33,14 @@ import type { Task } from '@/types'
  * invented all of that separately and got every one of them different; the
  * rule is copy the pattern, then justify each deviation.
  *
- * The grouping is the dashboard's own: quotas sit under their period, with the
- * same header word and the same progress bar, using `groupByPeriod` from
- * TrackPanel rather than a second copy of it. That is also why the period is
- * no longer repeated on every row — the card it sits in already says it.
+ * The grouping is by LABEL (Trent, 2026-09-08: "I think we need to have one
+ * label for quotas… there's a bunch of stuff for the kids and there are other
+ * things"). This page is where quotas are worked on as a set, and the set that
+ * matters there is the domain — kids, health, house — not the cadence. The
+ * dashboard's Track panel keeps `groupByPeriod`: it answers "what is left this
+ * week", where the period IS the question. So the two surfaces group
+ * differently on purpose, and each row here carries its own period tag, since
+ * a label group mixes days, weeks and months.
  */
 export function QuotasView({
   onUndo,
@@ -132,7 +138,7 @@ export function QuotasView({
     onCompleted,
   })
 
-  const groups = useMemo(() => groupByPeriod(tasks ?? []), [tasks])
+  const groups = useMemo(() => groupByLabel(tasks ?? []), [tasks])
   const orderedIds = useMemo(() => groups.flatMap((g) => g.tasks.map((t) => t.id)), [groups])
 
   if (tasks === null)
@@ -165,9 +171,9 @@ export function QuotasView({
       ) : (
         <div className="space-y-2.5">
           {groups.map((group) => (
-            <QuotaPeriodCard
-              key={group.period ?? 'none'}
-              period={group.period}
+            <QuotaGroupCard
+              key={group.label ?? 'unlabelled'}
+              label={group.label}
               tasks={group.tasks}
               selectedIds={selectedIds}
               onSelect={(task, e) => {
@@ -226,60 +232,60 @@ function EmptyState() {
 }
 
 /**
- * One period's quotas, in the dashboard's own card: the word top-left, the
- * count top-right, a hairline that fills as the period's targets are met.
- * Identical to `PeriodCard` in TrackPanel by design — the two surfaces show the
- * same thing and should look like it.
+ * One label's quotas, in the same card the periods used to sit in: the name
+ * top-left, a count top-right.
+ *
+ * The count is quotas, NOT progress. The card used to carry the dashboard's
+ * summed bar ("7 of 23"), which was honest while a card held one period and is
+ * meaningless now that it holds several: two a day plus three a week plus one a
+ * month adds up to nothing anybody can act on. "3 quotas · 1 met" is the same
+ * information at a granularity that survives mixing, and each row still shows
+ * its own bar. `met` is `trackState`'s met — reached the target, still open.
  */
-function QuotaPeriodCard({
-  period,
+function QuotaGroupCard({
+  label,
   tasks,
   selectedIds,
   onSelect,
   onOpen,
 }: {
-  period: string | null
+  label: string | null
   tasks: Task[]
   selectedIds: Set<number>
   onSelect: (task: Task, e: React.MouseEvent) => void
   onOpen: (task: Task) => void
 }) {
-  const word = period ? periodShort(period) : 'no period'
-  const s = trackSummary(tasks)
-  const met = s.total > 0 && s.done >= s.total
+  const { labelConfig } = useLabelConfig()
+  // "Unlabelled" rather than "no label": it is a group of things, named the way
+  // the other groups are named. It always sorts last (see `groupByLabel`).
+  const name = label ?? 'Unlabelled'
+  const colorClasses = label ? getLabelClasses(label, labelConfig) : null
+  const { count, met } = quotaGroupSummary(tasks)
 
   return (
-    <div className="bg-muted/30 rounded-2xl px-2 pt-2 pb-2.5" data-quota-period={word}>
-      <div className="flex items-center gap-2 px-1 pb-1.5">
-        <span className="text-muted-foreground text-[11px] font-semibold tracking-widest uppercase">
-          {word}
-        </span>
+    <div
+      className="bg-muted/30 rounded-2xl px-2 pt-2 pb-2.5"
+      data-quota-group={label ?? 'unlabelled'}
+    >
+      <div className="flex items-center gap-2 px-1 pb-2.5">
+        {/* The label wears its registry colour, exactly as its chip does in the
+            filter bar and the task editor; a label with no colour configured
+            reads as the plain group heading the periods used to have. */}
         <span
           className={cn(
-            'ml-auto text-xs whitespace-nowrap tabular-nums',
-            met ? 'text-green-700 dark:text-green-400' : 'text-muted-foreground',
+            'text-[11px] font-semibold tracking-widest uppercase',
+            colorClasses ? cn('rounded-full px-2 py-0.5', colorClasses) : 'text-muted-foreground',
           )}
         >
-          <span className="text-foreground font-medium">{s.done}</span> of {s.total}
+          {name}
+        </span>
+        <span className="text-muted-foreground ml-auto text-xs whitespace-nowrap">
+          <span className="text-foreground font-medium tabular-nums">{count}</span>{' '}
+          {count === 1 ? 'quota' : 'quotas'}
+          {met > 0 && <span className="text-green-700 dark:text-green-400"> · {met} met</span>}
         </span>
       </div>
-      <div
-        className="bg-muted mx-1 mb-2.5 h-1 overflow-hidden rounded-full"
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={s.total}
-        aria-valuenow={s.done}
-        aria-label={`${s.done} of ${s.total} ${period ?? ''}`.trim()}
-      >
-        <div
-          className={cn(
-            'h-full rounded-full transition-[width,background-color] duration-500 ease-out',
-            met ? 'bg-green-600' : 'bg-foreground/50',
-          )}
-          style={{ width: `${s.total > 0 ? (s.done / s.total) * 100 : 0}%` }}
-        />
-      </div>
-      <ul role="listbox" aria-multiselectable="true" aria-label={word} className="space-y-1">
+      <ul role="listbox" aria-multiselectable="true" aria-label={name} className="space-y-1">
         {tasks.map((task) => (
           <QuotaRow
             key={task.id}
@@ -312,6 +318,7 @@ function QuotaRow({
   // `state` already reflects the optimistic count — re-wrapping it in
   // trackState was a no-op.
   const { state, log: logProgress } = useTrackProgress(task)
+  const period = periodLabel(task.rrule)
 
   return (
     <li
@@ -370,6 +377,18 @@ function QuotaRow({
           )}
         >
           <span className="text-foreground font-medium">{state.current}</span> / {state.target}
+        </span>
+
+        {/* The period, on the row rather than on the card: the groups are
+            labels now, so a card holds a daily quota next to a monthly one and
+            "0 / 2" alone would not say which. Deliberately OUTSIDE
+            `data-quota-count` — that hook is asserted on exactly. A quota with
+            no rule says so instead of showing a blank column. */}
+        <span
+          data-quota-period
+          className="text-muted-foreground w-16 shrink-0 text-xs whitespace-nowrap"
+        >
+          · {period ? periodShort(period) : 'no period'}
         </span>
 
         {/* Both directions. This was the only surface where a mis-log could not

--- a/src/components/TrackPanel.tsx
+++ b/src/components/TrackPanel.tsx
@@ -41,8 +41,11 @@ import type { Task } from '@/types'
  *   under your finger" complaint applied verbatim here.
  * - "Met" is a state, not an exit: green check, count keeps going (3/2).
  *
- * Tracked tasks still appear as plain rows in the All / Projects lists (with a
- * "0 / 4" chip and no controls); logging happens here.
+ * This panel and the Quotas page are the ONLY places a quota appears (Trent,
+ * 2026-09-08: "a quota is not a task"). It used to be a plain row in the All
+ * and Projects lists too, wearing a "0 / 4" chip and no controls; the
+ * dashboard now filters tracked rows out of every list, which is why this
+ * panel is handed the unfiltered corpus rather than the list's own array.
  */
 export function TrackPanel({ tasks }: { tasks: Task[] }) {
   const { trackExpanded: open, setTrackExpanded: setOpen } = useTrackPanelPreference()

--- a/src/core/ai/enrichment.ts
+++ b/src/core/ai/enrichment.ts
@@ -44,6 +44,7 @@ import { buildEnrichmentUserPrompt, buildReminderEnrichmentUserPrompt } from './
 import { listTimeSlots } from '@/core/time-slots'
 import { currentSlot, parseHHMM, type TimeSlot } from '@/lib/time-slot-assign'
 import { parseCadence, buildSchedule } from '@/lib/reminder-rule'
+import { isTracked } from '@/lib/track'
 import { EnrichmentResultSchema } from './types'
 import type { EnrichmentResult } from './types'
 import { enrichmentQuery } from './enrichment-slot'
@@ -757,6 +758,16 @@ interface FieldChanges {
  *
  * Labels are merged (AI labels added to existing), and `ai-to-process` is
  * always removed from the final label set.
+ *
+ * §5: on a QUOTA, everything schedule-shaped is skipped — a quota has no due
+ * date and its rrule is a bare period rule that names the period it counts
+ * within, not a day to occur on. These clauses are raw SQL, so they bypass the
+ * guards in `collectFieldChanges` entirely. Two ways in: a user re-enriches a
+ * quota by adding `ai-to-process`, or an enrichment is already in flight when
+ * the task is converted into a quota. `task` here is the re-read from
+ * `applyEnrichment`, so this sees the row's state at write time rather than at
+ * dispatch time. Labels, priority, title and notes still apply — those mean the
+ * same thing on a quota.
  */
 function collectEnrichmentChanges(
   task: Task,
@@ -775,8 +786,11 @@ function collectEnrichmentChanges(
     fieldsChanged.push('title')
   }
 
+  // §5: a quota has no due date, no schedule to derive and no recurrence mode.
+  const tracked = isTracked(task)
+
   // Due date — always overwrite
-  if (enrichment.due_at) {
+  if (!tracked && enrichment.due_at) {
     if (enrichment.due_at !== task.due_at) {
       setClauses.push('due_at = ?')
       values.push(enrichment.due_at)
@@ -826,7 +840,7 @@ function collectEnrichmentChanges(
   }
 
   // RRULE — always overwrite
-  if (enrichment.rrule) {
+  if (!tracked && enrichment.rrule) {
     if (enrichment.rrule !== task.rrule) {
       setClauses.push('rrule = ?')
       values.push(enrichment.rrule)
@@ -868,7 +882,7 @@ function collectEnrichmentChanges(
   }
 
   // Recurrence mode — overwrite if AI extracted a value
-  if (enrichment.recurrence_mode) {
+  if (!tracked && enrichment.recurrence_mode) {
     if (enrichment.recurrence_mode !== task.recurrence_mode) {
       setClauses.push('recurrence_mode = ?')
       values.push(enrichment.recurrence_mode)

--- a/src/core/ai/quick-take.ts
+++ b/src/core/ai/quick-take.ts
@@ -20,6 +20,7 @@
 
 import { DateTime } from 'luxon'
 import { getTasks } from '@/core/tasks'
+import { isTracked } from '@/lib/track'
 import { getProjectNameMap } from '@/core/projects'
 import { isAIEnabled, aiQuery } from './sdk'
 import { quickTakeSlotQuery } from './quick-take-slot'
@@ -235,12 +236,24 @@ export function buildTaskStats(tasks: QuickTakeTask[], timezone: string): TaskSt
 /**
  * Build a compact task list + stats from the database for the given user.
  * Production entry point — fetches tasks and resolves project names.
+ *
+ * Exported for the same reason `formatCompactTaskList` is: it decides WHICH
+ * rows the model is shown, and that decision needs a test that does not go
+ * near the SDK.
  */
-function buildFromDb(
+export function buildFromDb(
   userId: number,
   timezone: string,
 ): { text: string; count: number; stats: TaskStats; tasks: QuickTakeTask[] } {
-  const tasks = getTasks({ userId, done: false })
+  // Quick Take reads the TASK list. Quotas (§5) and reminders (§6) are not in
+  // it — they live on their own surfaces — so neither is described to the
+  // model or counted in the stats it is handed. Quotas leak loudest now that
+  // they carry no date: every one of them landed in the `undated` bucket, so
+  // "you have N tasks with no due date" was inflated by the whole quota set
+  // and the compact list named them as things to do. Same filter as
+  // `buildTaskSummaries` (task-summaries.ts), which feeds What's Next and
+  // Insights.
+  const tasks = getTasks({ userId, done: false }).filter((t) => !isTracked(t) && !t.is_reminder)
   if (tasks.length === 0) {
     return {
       text: '(none)',

--- a/src/core/ai/task-summaries.ts
+++ b/src/core/ai/task-summaries.ts
@@ -7,6 +7,7 @@
 
 import { getTasks } from '@/core/tasks'
 import { getProjectNameMap } from '@/core/projects'
+import { isTracked } from '@/lib/track'
 import type { TaskSummary } from './types'
 
 /**
@@ -14,9 +15,16 @@ import type { TaskSummary } from './types'
  *
  * Fetches the user's active (not done) tasks and enriches them with
  * project names using a single bulk query instead of per-task lookups.
+ *
+ * Quotas are not candidates (§5). What's-Next and Insights answer questions
+ * about the task list, and a quota is not in it — recommending one would
+ * return an id the dashboard cannot show, which inflates the AI chip's count
+ * and points it at a row that isn't there. "Four times this week" also has
+ * none of the inputs these features reason over: no due date, no deadline, no
+ * debt.
  */
 export function buildTaskSummaries(userId: number): TaskSummary[] {
-  const tasks = getTasks({ userId, done: false })
+  const tasks = getTasks({ userId, done: false }).filter((t) => !isTracked(t))
   if (tasks.length === 0) return []
 
   // Pre-fetch all project names in one query to avoid N+1

--- a/src/core/db/index.ts
+++ b/src/core/db/index.ts
@@ -240,6 +240,39 @@ function runMigrations(database: Database.Database): void {
 
   backfillLabelRegistry(database)
   backfillTimeSlots(database)
+  clearQuotaDueDates(database)
+}
+
+/**
+ * §5: a quota has no due date — drop the ones already stored (2026-09-08).
+ *
+ * Every quota in the corpus carries a `due_at` left over from the life it had
+ * before it became one, and the §9 migration that rewrote quota rules to the
+ * bare period ("FREQ=WEEKLY") did not touch it. It was never the period
+ * boundary and was never true: on the dev corpus, 15 of 19 quotas held the
+ * same date in the past while their real period anchor
+ * (`progress_period_start`) sat days later. That stale date is what made a
+ * quota show up as overdue debt in counts and offer a snooze grid.
+ *
+ * `original_due_at` goes with it: it is the occurrence origin of a due date
+ * that no longer exists, and left behind it makes `is_snoozed` true in the API
+ * response for a row that cannot be snoozed.
+ *
+ * Data-only, so there is no new column to hang a `hasColumn` guard on and no
+ * migrations table in this app to record a version in. It is instead
+ * idempotent by construction — the WHERE clause matches nothing once it has
+ * run — and left to run on every start, where it also repairs any quota that
+ * somehow acquires a date again.
+ *
+ * Exported so a behavioral test can call it directly.
+ */
+export function clearQuotaDueDates(database: Database.Database): void {
+  database.exec(
+    `UPDATE tasks
+        SET due_at = NULL, original_due_at = NULL
+      WHERE (is_tracked = 1 OR progress_target > 1)
+        AND (due_at IS NOT NULL OR original_due_at IS NOT NULL)`,
+  )
 }
 
 /**

--- a/src/core/projects/index.ts
+++ b/src/core/projects/index.ts
@@ -31,6 +31,13 @@ export function getProjectNameMap(projectIds: number[]): Map<number, string> {
 
 /**
  * Get all projects accessible to a user (owned + shared), with task counts.
+ *
+ * The counts are of what the project's list will actually show, so the two
+ * populations that are not tasks are excluded: reminders (§6) from
+ * `overdue_count`, as before, and quotas (§5) from both — a quota is never in
+ * a project's list and is never late (Trent, 2026-09-08). Spelled as
+ * `is_tracked = 0 AND progress_target <= 1` because that is the negation of
+ * `isTracked` (src/lib/track.ts), which either column can satisfy on its own.
  */
 export function getProjects(userId: number): Project[] {
   const db = getDb()
@@ -43,11 +50,13 @@ export function getProjects(userId: number): Project[] {
         (SELECT COUNT(*) FROM tasks t
          WHERE t.project_id = p.id AND t.user_id = ?
            AND t.done = 0 AND t.deleted_at IS NULL AND t.archived_at IS NULL
+           AND t.is_tracked = 0 AND t.progress_target <= 1
         ) AS active_count,
         (SELECT COUNT(*) FROM tasks t
          WHERE t.project_id = p.id AND t.user_id = ?
            AND t.done = 0 AND t.deleted_at IS NULL AND t.archived_at IS NULL
            AND t.is_reminder = 0
+           AND t.is_tracked = 0 AND t.progress_target <= 1
            AND t.due_at IS NOT NULL AND datetime(t.due_at) < datetime(?)
         ) AS overdue_count
       FROM projects p

--- a/src/core/tasks/bulk.ts
+++ b/src/core/tasks/bulk.ts
@@ -18,6 +18,7 @@ import { incrementDailyStat } from '@/core/stats'
 import { ValidationError, ForbiddenError } from '@/core/errors'
 import { formatBulkEditDescription, formatSnoozeTarget } from '@/lib/field-labels'
 import { formatDurationDelta } from '@/lib/format-date'
+import { validateLabelsExist } from '@/core/labels'
 import { getTaskById } from './create'
 import { canUserAccessTask } from './update'
 import {
@@ -452,6 +453,28 @@ export interface BulkEditResult {
 }
 
 /**
+ * §7.2: a label typed while editing SEVERAL rows has to reach the registry.
+ *
+ * `collectFieldChanges` writes `labels` as raw SQL, so a name that exists on no
+ * other task was written to every selected row and then known to nothing: the
+ * next editor did not offer the chip, and the filter bar had no idea it
+ * existed. The Quotas page routes any selection of two or more through this
+ * endpoint, so "select two quotas → Label → + New → kids → Save" was exactly
+ * the broken case.
+ *
+ * Only when the caller asks. `validateLabelsExist` THROWS on an unknown name
+ * without the flag, and this endpoint has never validated labels at all —
+ * turning that on for every existing caller would start rejecting writes that
+ * work today. `existing: []` because the flag means "register whatever is
+ * missing", independent of what the selected rows already carry.
+ */
+function registerBulkEditLabels(userId: number, changes: BulkEditChanges): void {
+  if (changes.create_label !== true) return
+  const incoming = [...(changes.labels ?? []), ...(changes.labels_add ?? [])]
+  if (incoming.length > 0) validateLabelsExist(userId, incoming, [], true)
+}
+
+/**
  * Bulk edit
  *
  * Applies the same changes to all specified tasks.
@@ -468,6 +491,8 @@ export function bulkEdit(options: BulkEditOptions): BulkEditResult {
     ...changes,
     ...(perTask?.[String(task.id)] ?? {}),
   })
+
+  registerBulkEditLabels(userId, changes)
 
   // Reject rrule changes on done tasks — setting rrule on a done+archived task creates
   // an impossible state (done=1 + rrule set) that the system never produces organically

--- a/src/core/tasks/bulk.ts
+++ b/src/core/tasks/bulk.ts
@@ -210,11 +210,9 @@ function filterForBulkSnooze(tasks: Task[], includeTaskIds?: Set<number>): BulkS
   // that bulk paths must not modal-block, and per L1 sweep participation
   // carries no per-item intent to confirm.
   //
-  // §5: a quota is never late either. It carries a vestigial `due_at` (the iOS
-  // widget draws its pace tick from it), and the counts stopped calling that
-  // overdue on 2026-09-06 — so a sweep that still moved it would have been
-  // rescheduling items the app says are never overdue, and shifting the exact
-  // timestamp the widget reads. Counted with the reminders as "not debt".
+  // §5: a quota is never late either — since 2026-09-08 it has no `due_at` at
+  // all, so there is nothing for a sweep to move. Counted with the reminders as
+  // "not debt".
   const snoozable = tasks.filter((t) => !t.is_reminder && !isTracked(t))
   const reminderSkipped = tasks.length - snoozable.length
 
@@ -486,6 +484,26 @@ export function bulkEdit(options: BulkEditOptions): BulkEditResult {
     }
   }
 
+  // §5: a quota has no due date, so a date-bearing batch skips it rather than
+  // failing. `collectFieldChanges` throws QUOTA_DUE_DATE_MESSAGE on a tracked
+  // row given a date, and one throw aborts the whole transaction — a mixed
+  // selection lost the plain tasks' edits too. The snooze path below already
+  // filtered quotas out through `filterForBulkSnooze`, but only for a date sent
+  // WITHOUT an rrule; `{ due_at, rrule }` together, and a per-task date, went
+  // straight through. Runs before that filter so the two never double-count.
+  let quotaSkippedCount = 0
+  const bearsDate =
+    changes.due_at != null ||
+    Object.values(perTask ?? {}).some((p) => (p as { due_at?: string | null }).due_at != null)
+  if (bearsDate) {
+    const beforeCount = tasks.length
+    tasks = tasks.filter((t) => !isTracked(t))
+    quotaSkippedCount = beforeCount - tasks.length
+    if (tasks.length === 0) {
+      return { tasksAffected: 0, tasksSkipped: rruleSkippedCount + quotaSkippedCount }
+    }
+  }
+
   // Priority filter for snooze edits — same logic as bulkSnooze (P3/P4 excluded).
   // A due_at change is only a snooze when rrule is not being changed. If rrule is explicitly
   // set (even to null), the due_at change is part of a schedule change, not a snooze.
@@ -496,7 +514,10 @@ export function bulkEdit(options: BulkEditOptions): BulkEditResult {
     snoozeSkippedCount = tasks.length - eligible.length
     tasks = eligible
     if (tasks.length === 0) {
-      return { tasksAffected: 0, tasksSkipped: snoozeSkippedCount }
+      return {
+        tasksAffected: 0,
+        tasksSkipped: rruleSkippedCount + quotaSkippedCount + snoozeSkippedCount,
+      }
     }
   }
 
@@ -588,7 +609,7 @@ export function bulkEdit(options: BulkEditOptions): BulkEditResult {
 
     return {
       tasksAffected: snapshots.length,
-      tasksSkipped: snoozeSkippedCount + rruleSkippedCount,
+      tasksSkipped: snoozeSkippedCount + rruleSkippedCount + quotaSkippedCount,
     }
   })
 

--- a/src/core/tasks/create.ts
+++ b/src/core/tasks/create.ts
@@ -12,7 +12,9 @@ import { emitSyncEvent, emitTaskCreatedEvent } from '@/lib/sync-events'
 import { dispatchWebhookEvent } from '@/core/webhooks/dispatch'
 import { formatTaskResponse } from '@/lib/format-task'
 import { incrementDailyStat } from '@/core/stats'
-import { NotFoundError, ForbiddenError } from '@/core/errors'
+import { NotFoundError, ForbiddenError, ValidationError } from '@/core/errors'
+import { QUOTA_DUE_DATE_MESSAGE } from '@/core/validation'
+import { isTracked } from '@/lib/track'
 import { isAIEnabled } from '@/core/ai'
 import { validateLabelsExist, PROVENANCE_LABELS } from '@/core/labels'
 
@@ -54,9 +56,25 @@ export function createTask(options: CreateTaskOptions): Task {
     throw new ForbiddenError('Access denied to project')
   }
 
-  // Compute due_at if rrule provided but no due_at
-  let dueAt = input.due_at ?? null
-  if (input.rrule && !dueAt) {
+  // §5: a quota is not a task — it has no due date (see QUOTA_DUE_DATE_MESSAGE).
+  // Asked of the row being created, not of one field: `progress_target > 1`
+  // opts in by itself, `is_tracked` marks a quota whose target is 1.
+  const tracked = isTracked({
+    is_tracked: input.is_tracked ?? false,
+    progress_target: input.progress_target ?? 1,
+  })
+  if (tracked && input.due_at) {
+    throw new ValidationError(QUOTA_DUE_DATE_MESSAGE)
+  }
+
+  // Compute due_at if rrule provided but no due_at.
+  //
+  // A quota is skipped: its rrule is a bare period rule ("FREQ=WEEKLY"), which
+  // names the period the count runs over rather than a day to occur on, so
+  // asking rrule.js for its "first occurrence" produced an arbitrary weekday —
+  // which is how quotas ended up carrying a stray local-midnight due date.
+  let dueAt = tracked ? null : (input.due_at ?? null)
+  if (!tracked && input.rrule && !dueAt) {
     const firstOccurrence = computeFirstOccurrence(input.rrule, null, userTimezone)
     dueAt = firstOccurrence.toISOString()
   }

--- a/src/core/tasks/create.ts
+++ b/src/core/tasks/create.ts
@@ -214,7 +214,7 @@ export function getTaskById(taskId: number): Task | null {
            rrule, recurrence_mode, anchor_time, anchor_dow, anchor_dom,
            original_due_at, last_notified_at, last_critical_alert_at, auto_snooze_minutes,
            deleted_at, archived_at, labels,
-           progress_target, progress_current, is_reminder, is_tracked,
+           progress_target, progress_current, progress_period_start, is_reminder, is_tracked,
            completion_count, snooze_count, skip_count, first_completed_at, last_completed_at,
            notes, created_at, updated_at
     FROM tasks WHERE id = ?
@@ -332,7 +332,8 @@ export function getTasks(options: GetTasksOptions): Task[] {
            tasks.anchor_dow, tasks.anchor_dom, tasks.original_due_at,
            tasks.last_notified_at, tasks.last_critical_alert_at, tasks.auto_snooze_minutes,
            tasks.deleted_at, tasks.archived_at,
-           tasks.labels, tasks.progress_target, tasks.progress_current, tasks.is_reminder, tasks.is_tracked,
+           tasks.labels, tasks.progress_target, tasks.progress_current,
+           tasks.progress_period_start, tasks.is_reminder, tasks.is_tracked,
            tasks.completion_count, tasks.snooze_count, tasks.skip_count,
            tasks.first_completed_at, tasks.last_completed_at,
            tasks.notes, tasks.created_at, tasks.updated_at
@@ -372,6 +373,7 @@ interface TaskRow {
   labels: string
   progress_target: number
   progress_current: number
+  progress_period_start: string | null
   is_reminder: number
   is_tracked: number
   completion_count: number
@@ -412,6 +414,7 @@ function rowToTask(row: TaskRow): Task {
     // produce NaN in pace math.
     progress_target: row.progress_target ?? 1,
     progress_current: row.progress_current ?? 0,
+    progress_period_start: row.progress_period_start ?? null,
     is_reminder: (row.is_reminder ?? 0) === 1,
     is_tracked: (row.is_tracked ?? 0) === 1,
     completion_count: row.completion_count,

--- a/src/core/tasks/helpers/collect-field-changes.ts
+++ b/src/core/tasks/helpers/collect-field-changes.ts
@@ -320,15 +320,29 @@ function collectRruleChanges(
 
   trackField(data, 'rrule', task.rrule, input.rrule)
 
-  // The occurrence origin belongs to the OLD schedule, so any rrule change
-  // takes it with it — including a change TO null, which it did not until
-  // 2026-09-08. A task created recurring has `original_due_at` set to its first
-  // occurrence, so "clear recurrence and pick a date" left that stale value
-  // behind: `is_snoozed` stayed true in the API response and the row drew the
-  // snoozed indicator, for an edit that was a re-schedule rather than a
-  // deferral. The other half of the same finding is the snooze branch below,
-  // which no longer fires when the rrule changed.
-  if (task.original_due_at) {
+  // When an rrule change takes the occurrence origin with it — and when it
+  // must not.
+  //
+  // The origin belongs to the schedule the task had, so a change to a NEW
+  // schedule drops it. That has always been true. Clearing the rule to null was
+  // added on 2026-09-08 for `{ rrule: null, due_at: X }` — "clear recurrence and
+  // pick a date", which is a re-schedule and must not read as a snooze — but it
+  // was applied to EVERY clear, and that was too wide: `{ rrule: null }` alone
+  // on a genuinely snoozed recurring task (snooze_count 2, origin = the
+  // pre-snooze date) kept the deferred `due_at` and the count while losing the
+  // origin, so the row stopped drawing its snoozed stripe and the quick panel's
+  // age anchor jumped back to `created_at`. A date has to be arriving in the
+  // same request for the clear to mean a re-schedule.
+  //
+  // An explicit `reset_original_due_at` always wins: it is the user saying what
+  // the origin is, in the same breath. `collectBasicFields` has already pushed
+  // it, and SQLite takes the last clause, so without this guard the reset was
+  // silently overridden — including on the pre-existing `{ reset, rrule: <new
+  // rule> }` path.
+  const rruleTakesTheOrigin =
+    !input.reset_original_due_at && (input.rrule !== null || input.due_at != null)
+
+  if (rruleTakesTheOrigin && task.original_due_at) {
     data.setClauses.push('original_due_at = NULL')
     if (!data.fieldsChanged.includes('original_due_at')) {
       data.fieldsChanged.push('original_due_at')

--- a/src/core/tasks/helpers/collect-field-changes.ts
+++ b/src/core/tasks/helpers/collect-field-changes.ts
@@ -453,8 +453,17 @@ function collectDueAtChanges(
   trackField(data, 'due_at', task.due_at, input.due_at)
 
   // Apply snooze logic if task had a previous due_at and is being moved to a new date
-  // (not when clearing due_at to null — that's not a snooze)
-  if (task.due_at !== null && input.due_at !== null) {
+  // (not when clearing due_at to null — that's not a snooze).
+  //
+  // Never when the rrule changed in the same request: that is a RE-SCHEDULE,
+  // not a deferral. `{ rrule: null, due_at: <date> }` is exactly what the quick
+  // panel sends when a user clears recurrence and picks a date, and it only
+  // started reaching this branch when the guard above was widened from
+  // `due_at === null` to "any explicit date" — before that the payload lost its
+  // date instead. Without this it would bump `snooze_count`, back-fill
+  // `original_due_at`, fire the snooze stat and the `snooze` activity entry,
+  // and draw the snoozed indicator on a row nobody snoozed.
+  if (!rruleChanged && task.due_at !== null && input.due_at !== null) {
     data.isSnoozeScenario = true
 
     // Set original_due_at if not already set (preserve existing)

--- a/src/core/tasks/helpers/collect-field-changes.ts
+++ b/src/core/tasks/helpers/collect-field-changes.ts
@@ -8,7 +8,9 @@
 import { getDb } from '@/core/db'
 import type { Task, TaskUpdateInput } from '@/types'
 import { deriveAnchorFields, computeFirstOccurrence } from '@/core/recurrence'
-import { NotFoundError, ForbiddenError } from '@/core/errors'
+import { NotFoundError, ForbiddenError, ValidationError } from '@/core/errors'
+import { QUOTA_DUE_DATE_MESSAGE } from '@/core/validation'
+import { isTracked } from '@/lib/track'
 
 /** Extended input type that supports additive/subtractive label operations and origin reset */
 export type FieldChangesInput = TaskUpdateInput & {
@@ -78,8 +80,39 @@ function trackField<K extends keyof Task>(
  * @returns Field change data ready for SQL execution
  */
 export function collectFieldChanges(options: CollectFieldChangesOptions): FieldChangeData {
-  const { task, input, userId, userTimezone, skipProjectValidation = false } = options
+  const { task, userId, userTimezone, skipProjectValidation = false } = options
   const now = options.now ?? new Date()
+
+  // §5: what this update leaves behind — a quota, or an ordinary task.
+  //
+  // Asked of the RESULTING row rather than of the payload, the way the
+  // reminder/track exclusivity check in updateTask is: `is_tracked: false` on
+  // its own retires a quota, and `is_tracked: true` on its own converts a task
+  // into one, and neither request mentions the other's fields.
+  const wasTracked = isTracked(task)
+  const willBeTracked = isTracked({
+    is_tracked: options.input.is_tracked ?? task.is_tracked,
+    progress_target: options.input.progress_target ?? task.progress_target,
+  })
+
+  // A quota has no due date, so it cannot be given one — by a snooze, by the
+  // task editor, or by a bulk edit that swept it up.
+  if (willBeTracked && options.input.due_at) {
+    throw new ValidationError(QUOTA_DUE_DATE_MESSAGE)
+  }
+
+  // Retiring a quota takes its rule with it.
+  //
+  // A quota's rule is a bare period rule ("FREQ=WEEKLY"), legal only while the
+  // row is tracked (`periodRuleOnlyWhenTracked`). Left behind on the retired
+  // task it would be evaluated as a schedule — and with no due_at to anchor
+  // it, `effectiveDueAt` asks rrule.js for today's occurrence of a bare weekly
+  // rule, which lands on an arbitrary weekday. Clearing it here rather than in
+  // updateTask means bulk edit retires correctly too.
+  const input: FieldChangesInput =
+    wasTracked && !willBeTracked && options.input.rrule === undefined
+      ? { ...options.input, rrule: null }
+      : options.input
 
   const data: FieldChangeData = {
     setClauses: [],
@@ -94,12 +127,44 @@ export function collectFieldChanges(options: CollectFieldChangesOptions): FieldC
   collectBasicFields(data, task, input, userId, skipProjectValidation)
 
   // Track rrule changes with anchor derivation
-  const rruleChanged = collectRruleChanges(data, task, input, userTimezone, now)
+  const rruleChanged = collectRruleChanges(data, task, input, userTimezone, now, willBeTracked)
 
   // Track due_at changes with snooze detection
   collectDueAtChanges(data, task, input, rruleChanged)
 
+  // Whatever date the row still carried, drop it if it is (or is becoming) a quota
+  collectQuotaDateClear(data, task, willBeTracked)
+
   return data
+}
+
+/**
+ * §5: a quota carries no date, whether it was just converted into one or has
+ * been one all along.
+ *
+ * Runs last, and only when nothing above already decided `due_at`, so an
+ * explicit `due_at: null` in the payload is not written twice. Because it
+ * looks at the row rather than the payload it is also self-healing: a legacy
+ * quota that still holds a date from before the migration loses it the first
+ * time anything about it is edited.
+ *
+ * `original_due_at` goes with it — it is the occurrence origin of a due date
+ * that no longer exists, and left behind it makes `is_snoozed` true on a row
+ * that cannot be snoozed.
+ */
+function collectQuotaDateClear(data: FieldChangeData, task: Task, willBeTracked: boolean): void {
+  if (!willBeTracked) return
+  if (data.afterState.due_at !== undefined) return
+
+  if (task.due_at !== null) {
+    trackField(data, 'due_at', task.due_at, null)
+  }
+  if (task.original_due_at !== null && !data.fieldsChanged.includes('original_due_at')) {
+    data.setClauses.push('original_due_at = NULL')
+    data.fieldsChanged.push('original_due_at')
+    data.beforeState.original_due_at = task.original_due_at
+    data.afterState.original_due_at = null
+  }
 }
 
 /**
@@ -247,6 +312,7 @@ function collectRruleChanges(
   input: FieldChangesInput,
   userTimezone: string,
   now: Date,
+  willBeTracked: boolean,
 ): boolean {
   if (input.rrule === undefined || input.rrule === task.rrule) {
     return false
@@ -320,8 +386,14 @@ function collectRruleChanges(
     // just frozen at its last occurrence, so its due_at follows the new
     // schedule: the reminder editor's "move it to the evening" must not leave
     // a due date claiming last Tuesday's morning.
+    //
+    // A quota (§5) is skipped entirely: it has no due date to compute, and its
+    // rule is a bare period rule that rrule.js would place on an arbitrary
+    // weekday. This is what the quota editor's "one field this editor promises
+    // not to touch" note used to be working around — it sent the rule and the
+    // server stamped a date behind it.
     const isOverdue = task.due_at && new Date(task.due_at) < now
-    if (input.due_at === undefined && (!isOverdue || task.is_reminder)) {
+    if (!willBeTracked && input.due_at === undefined && (!isOverdue || task.is_reminder)) {
       const nextOccurrence = computeFirstOccurrence(input.rrule, anchors.anchor_time, userTimezone)
       const nextDueAt = nextOccurrence.toISOString()
 
@@ -362,11 +434,19 @@ function collectDueAtChanges(
   if (rruleChanged) {
     // Only process due_at if:
     // 1. rrule is being cleared to null, AND
-    // 2. due_at is explicitly being set to null, AND
+    // 2. due_at is explicitly present in the input, AND
     // 3. due_at wasn't already processed by collectRruleChanges
-    const isClearingRruleAndDueAt =
-      input.rrule === null && input.due_at === null && data.afterState.due_at === undefined
-    if (!isClearingRruleAndDueAt) return
+    //
+    // Clearing the rule is the one case where `collectRruleChanges` computes
+    // nothing, so an explicit date in the same request has to be applied here
+    // or it is silently dropped. That used to be limited to `due_at: null`,
+    // which was enough while the only caller was "clear both"; retiring a
+    // quota now injects `rrule: null` of its own accord, so
+    // `{ is_tracked: false, due_at: <date> }` — retire this and give it a real
+    // date — would otherwise lose the date.
+    const isClearingRruleWithExplicitDueAt =
+      input.rrule === null && input.due_at !== undefined && data.afterState.due_at === undefined
+    if (!isClearingRruleWithExplicitDueAt) return
   }
   if (input.due_at === undefined || input.due_at === task.due_at) return
 

--- a/src/core/tasks/helpers/collect-field-changes.ts
+++ b/src/core/tasks/helpers/collect-field-changes.ts
@@ -320,6 +320,23 @@ function collectRruleChanges(
 
   trackField(data, 'rrule', task.rrule, input.rrule)
 
+  // The occurrence origin belongs to the OLD schedule, so any rrule change
+  // takes it with it — including a change TO null, which it did not until
+  // 2026-09-08. A task created recurring has `original_due_at` set to its first
+  // occurrence, so "clear recurrence and pick a date" left that stale value
+  // behind: `is_snoozed` stayed true in the API response and the row drew the
+  // snoozed indicator, for an edit that was a re-schedule rather than a
+  // deferral. The other half of the same finding is the snooze branch below,
+  // which no longer fires when the rrule changed.
+  if (task.original_due_at) {
+    data.setClauses.push('original_due_at = NULL')
+    if (!data.fieldsChanged.includes('original_due_at')) {
+      data.fieldsChanged.push('original_due_at')
+      data.beforeState.original_due_at = task.original_due_at
+    }
+    data.afterState.original_due_at = null
+  }
+
   if (input.rrule === null) {
     // Clearing recurrence - null out anchor fields and reset recurrence_mode
     data.setClauses.push('anchor_time = NULL, anchor_dow = NULL, anchor_dom = NULL')
@@ -366,16 +383,6 @@ function collectRruleChanges(
       data.beforeState.anchor_dom = task.anchor_dom
     }
     data.afterState.anchor_dom = anchors.anchor_dom
-
-    // Clear original_due_at when rrule changes
-    if (task.original_due_at) {
-      data.setClauses.push('original_due_at = NULL')
-      if (!data.fieldsChanged.includes('original_due_at')) {
-        data.fieldsChanged.push('original_due_at')
-        data.beforeState.original_due_at = task.original_due_at
-      }
-      data.afterState.original_due_at = null
-    }
 
     // Only auto-compute due_at if:
     // 1. User didn't explicitly pass due_at

--- a/src/core/tasks/helpers/compute-mark-done.ts
+++ b/src/core/tasks/helpers/compute-mark-done.ts
@@ -8,6 +8,7 @@
 
 import type { Task } from '@/types'
 import { computeNextOccurrence, isRecurring } from '@/core/recurrence'
+import { isTracked } from '@/lib/track'
 
 export interface MarkDoneStats {
   completionCount: number
@@ -17,7 +18,11 @@ export interface MarkDoneStats {
 
 export interface RecurringComputation {
   type: 'recurring'
-  nextDueAt: string
+  /**
+   * Null for a quota (§5): it has no due date, so the boundary advances
+   * nothing. See the tracked branch in `computeMarkDone`.
+   */
+  nextDueAt: string | null
   prevDueAt: string | null
   stats: MarkDoneStats
   fieldsChanged: string[]
@@ -57,18 +62,26 @@ export function computeMarkDone(
   }
 
   if (isRecurring(task.rrule)) {
-    const nextOccurrence = computeNextOccurrence({
-      rrule: task.rrule!,
-      recurrenceMode: task.recurrence_mode,
-      anchorTime: task.anchor_time,
-      timezone: userTimezone,
-      completedAt,
-      prevDueAt: task.due_at ? new Date(task.due_at) : null,
-    })
+    // §5: a quota has no due date, so there is no occurrence to advance — the
+    // boundary here is only the progress reset below. Asking anyway would be
+    // wrong twice over: a quota's rule is a bare period rule ("FREQ=WEEKLY")
+    // with no anchor and no previous date, so rrule.js would place the "next
+    // occurrence" on an arbitrary weekday and write that date back onto a row
+    // that is not supposed to have one.
+    const nextOccurrence = isTracked(task)
+      ? null
+      : computeNextOccurrence({
+          rrule: task.rrule!,
+          recurrenceMode: task.recurrence_mode,
+          anchorTime: task.anchor_time,
+          timezone: userTimezone,
+          completedAt,
+          prevDueAt: task.due_at ? new Date(task.due_at) : null,
+        })
 
     return {
       type: 'recurring',
-      nextDueAt: nextOccurrence.toISOString(),
+      nextDueAt: nextOccurrence?.toISOString() ?? null,
       prevDueAt: task.due_at,
       stats,
       fieldsChanged: [

--- a/src/core/tasks/skip.ts
+++ b/src/core/tasks/skip.ts
@@ -27,6 +27,7 @@ import { NotFoundError, ForbiddenError, ValidationError } from '@/core/errors'
 import { dispatchWebhookEvent } from '@/core/webhooks/dispatch'
 import { formatTaskResponse } from '@/lib/format-task'
 import { emitSyncEvent } from '@/lib/sync-events'
+import { isTracked } from '@/lib/track'
 import { getTaskById } from './create'
 import { canUserAccessTask } from './update'
 import type { Task } from '@/types'
@@ -72,15 +73,19 @@ export function skipOccurrence(options: SkipOccurrenceOptions): SkipOccurrenceRe
     let fieldsChanged: string[]
 
     if (recurring) {
-      const nextOccurrence = computeNextOccurrence({
-        rrule: task.rrule!,
-        recurrenceMode: task.recurrence_mode,
-        anchorTime: task.anchor_time,
-        timezone: userTimezone,
-        completedAt: new Date(),
-        prevDueAt: task.due_at ? new Date(task.due_at) : null,
-      })
-      const nextDueAt = nextOccurrence.toISOString()
+      // §5: a quota has no date to advance — see the same guard in
+      // `computeMarkDone`. Skipping one is still a period boundary, so the
+      // progress reset below stands.
+      const nextDueAt = isTracked(task)
+        ? null
+        : computeNextOccurrence({
+            rrule: task.rrule!,
+            recurrenceMode: task.recurrence_mode,
+            anchorTime: task.anchor_time,
+            timezone: userTimezone,
+            completedAt: new Date(),
+            prevDueAt: task.due_at ? new Date(task.due_at) : null,
+          }).toISOString()
 
       // §5: advancing the occurrence is a period boundary, so a tracked task's
       // progress resets here exactly as it would on completion.

--- a/src/core/tasks/snooze.ts
+++ b/src/core/tasks/snooze.ts
@@ -10,6 +10,7 @@ import type { Task } from '@/types'
 import { NotFoundError, ForbiddenError, ValidationError } from '@/core/errors'
 import { dispatchWebhookEvent } from '@/core/webhooks/dispatch'
 import { formatTaskResponse } from '@/lib/format-task'
+import { isTracked } from '@/lib/track'
 import { getTaskById } from './create'
 import { canUserAccessTask, updateTask } from './update'
 
@@ -63,6 +64,18 @@ export function snoozeTask(options: SnoozeTaskOptions): SnoozeResult {
   if (task.is_reminder) {
     throw new ValidationError(
       'Reminders cannot be snoozed — they stay in their time slot until completed',
+    )
+  }
+
+  // §5: a quota cannot be snoozed either, for the stronger reason that it has
+  // no due date to move (QUOTA_DUE_DATE_MESSAGE). "Four times this week" is a
+  // count over a period, not an appointment to defer. `collectFieldChanges`
+  // would refuse the underlying PATCH anyway; checking here names the
+  // operation the caller actually asked for. Bulk snooze skips quotas rather
+  // than failing the sweep (see `bulkSnooze`).
+  if (isTracked(task)) {
+    throw new ValidationError(
+      'Quotas cannot be snoozed — a quota is counted within its period, not due on a day',
     )
   }
 

--- a/src/core/undo/apply-fields.ts
+++ b/src/core/undo/apply-fields.ts
@@ -50,6 +50,14 @@ const VALID_TASK_COLUMNS = new Set([
   'progress_target',
   'progress_current',
   'skip_count',
+  // §5: the explicit quota flag. Missing here until 2026-09-08, which was not
+  // merely "undo does nothing": this allowlist THROWS on an unknown field, and
+  // `undoEntry` runs inside the caller's transaction, so the throw rolled back
+  // the `undone = 1` write too. The entry stayed at `undone = 0` and every
+  // later Undo found it again — one retire wedged the whole stack. Reached by
+  // retiring a quota (`is_tracked: false`) and by the quota editor, which
+  // sends `is_tracked: true` whenever the target or period is touched.
+  'is_tracked',
   // §6
   'is_reminder',
 ])
@@ -98,6 +106,12 @@ export function applyFieldsToTask(
         // Same reason as `done`: SQLite has no boolean type (§6).
         setClauses.push(`${dbColumn} = ?`)
         values.push((state as { is_reminder?: boolean }).is_reminder ? 1 : 0)
+      } else if (dbColumn === 'is_tracked') {
+        // Same reason again (§5). The snapshot holds the domain value, because
+        // `trackField` records `true`/`false` while binding 0/1 to the column —
+        // so without this branch better-sqlite3 refuses the raw JS boolean.
+        setClauses.push(`${dbColumn} = ?`)
+        values.push((state as { is_tracked?: boolean }).is_tracked ? 1 : 0)
       } else {
         setClauses.push(`${dbColumn} = ?`)
         values.push((state as Record<string, unknown>)[stateKey])

--- a/src/core/validation/index.ts
+++ b/src/core/validation/index.ts
@@ -20,6 +20,7 @@ export {
   validateBulkDelete,
   validateBulkSnoozeOverdue,
   TRACKED_REMINDER_MESSAGE,
+  QUOTA_DUE_DATE_MESSAGE,
 } from './task'
 
 export type {

--- a/src/core/validation/task.ts
+++ b/src/core/validation/task.ts
@@ -136,6 +136,21 @@ export const PERIOD_RULE_MESSAGE =
   'A bare period rule (e.g. FREQ=MONTHLY) is only valid on a tracked task'
 
 /**
+ * §5: a quota is not a task, so it has no due date (Trent, 2026-09-08).
+ *
+ * The period a quota counts within is carried by `progress_period_start` and
+ * named by the rrule's FREQ — see `period-rollover.ts`. A `due_at` on top of
+ * that is a second, contradictory clock: it made the row overdue in every
+ * count, offered a snooze grid, and drew a pace tick from a date that was
+ * never the period boundary. Enforced in the core (create.ts and
+ * collect-field-changes.ts) rather than in the Zod schema, because the schema
+ * sees only the payload and "is this row a quota?" is a question about the
+ * resulting row.
+ */
+export const QUOTA_DUE_DATE_MESSAGE =
+  'A quota has no due date — it is counted within its period, not due on a day'
+
+/**
  * Bulk operation ID array — bounded to prevent DoS via excessive DB queries.
  */
 const bulkIds = z

--- a/src/hooks/useDomainLabels.ts
+++ b/src/hooks/useDomainLabels.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import type { Label } from '@/core/labels'
+
+/**
+ * The user's domain labels, for a picker (REDESIGN-V03 §7.2).
+ *
+ * Only the DOMAIN facet: those carry meaning ("kids", "health", "house") and
+ * are the ones a person files something under. The `operational` facet is the
+ * `ai-*` machinery — provenance and processing state — which nothing should be
+ * able to hand-assign from a picker, so it is filtered out here rather than at
+ * every call site.
+ *
+ * The registry is the source, not `label_config`: that preference only says
+ * which labels have a COLOUR, so a label the user never coloured would be
+ * missing from the list. Colour still comes from `label_config` at render time.
+ *
+ * Fetched once per mount, like `useTimeSlots` — a label registry changes about
+ * as often as a time slot does. `reload` exists for the one moment it does
+ * change under us: registering a new label as part of a save.
+ *
+ * A failure returns an empty list rather than throwing. The editor then offers
+ * "none" and typing a new name, which is degraded but still usable; a throw
+ * would take the whole editor down over what is a list of suggestions.
+ */
+export function useDomainLabels(): { labels: string[]; reload: () => void } {
+  const [labels, setLabels] = useState<string[]>([])
+  const [nonce, setNonce] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetch('/api/labels')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (cancelled) return
+        const rows = (json?.data?.labels ?? []) as Label[]
+        setLabels(rows.filter((l) => l.facet === 'domain').map((l) => l.name))
+      })
+      .catch(() => {
+        if (!cancelled) setLabels([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [nonce])
+
+  const reload = useCallback(() => setNonce((n) => n + 1), [])
+
+  return { labels, reload }
+}

--- a/src/lib/task-counts.ts
+++ b/src/lib/task-counts.ts
@@ -26,14 +26,15 @@ export function countTasks(
   let today = 0
   for (const t of tasks) {
     if (!t.due_at) continue
-    // A quota is never late. It carries a `due_at` — vestigial, from before it
-    // was a quota, and still read by the iOS widget to draw its pace tick — but
-    // that date is not a promise: "four times this week" cannot be overdue on a
-    // Tuesday. The notifier already refuses to fire on tracked items
-    // (overdue-checker.ts, currently-due.ts); this makes the badges agree, so
-    // the app no longer shows a debt it would never chase (Trent, 2026-09-06:
-    // "I don't even know if they have reminders. Do they have times when
-    // they're reminded?" — no, and now nothing implies they do).
+    // A quota is never late: "four times this week" cannot be overdue on a
+    // Tuesday. Since 2026-09-08 a quota carries no `due_at` at all, so the line
+    // above normally settles it; this stays as the explicit statement of the
+    // rule, and catches a legacy row the migration has not reached yet. The
+    // notifier already refuses to fire on tracked items (overdue-checker.ts,
+    // currently-due.ts); this makes the badges agree, so the app no longer
+    // shows a debt it would never chase (Trent, 2026-09-06: "I don't even know
+    // if they have reminders. Do they have times when they're reminded?" — no,
+    // and now nothing implies they do).
     if (isTracked(t)) continue
     const due = new Date(t.due_at)
     if (due < now) overdue++

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -5,6 +5,7 @@
  * row component runs in the browser and only needs to read a task's tracked
  * state and name its period. Kept here so a client bundle never pulls core.
  */
+import { isReservedLabel } from '@/lib/label-vocabulary'
 import type { Task } from '@/types'
 
 /**
@@ -133,9 +134,18 @@ export function quotaGroupSummary(tasks: Pick<Task, 'progress_target' | 'progres
   return { count: tasks.length, met: tasks.filter((t) => trackState(t).met).length }
 }
 
-/** The one label a quota is filed under: the first it carries, or none. */
+/**
+ * The one label a quota is filed under: the first MEANING it carries, or none.
+ *
+ * Reserved `ai-*` labels are skipped. They are machinery, not filing — created
+ * by `createTask` (`ai-to-process`, `ai-proposed`, `ai-added`) and by
+ * enrichment (`ai-failed`), often without the user ever typing one. Taking
+ * `labels[0]` blindly gave a quota whose only label was operational a group
+ * header reading "AI-FAILED", and showed that as its pressed chip in the
+ * editor. A quota carrying nothing else is unlabelled, which is the truth.
+ */
 export function quotaLabelOf(quota: Pick<Task, 'labels'>): string | null {
-  return quota.labels?.[0] ?? null
+  return quota.labels?.find((l) => !isReservedLabel(l)) ?? null
 }
 
 /**
@@ -162,14 +172,29 @@ export function quotaLabelOf(quota: Pick<Task, 'labels'>): string | null {
 export function groupByLabel(
   quotas: Pick<Task, 'labels'>[],
 ): { label: string | null; tasks: Task[] }[] {
+  // Grouped case-INSENSITIVELY, displayed in the spelling seen first.
+  //
+  // The registry's UNIQUE is case-sensitive, so "Kids" and "kids" are two rows
+  // and can both end up on quotas. Grouping by the raw string then drew two
+  // separate cards whose headers both read "KIDS", which reads as a bug every
+  // time. `labels_add`/`labels_remove` already dedupe case-insensitively
+  // (collect-field-changes.ts), so this matches a rule the app already keeps
+  // rather than inventing one. Nothing about the schema changes: the two rows
+  // still exist, they just file together.
   const by = new Map<string | null, Task[]>()
+  const display = new Map<string, string>()
   for (const t of quotas as Task[]) {
     const label = quotaLabelOf(t)
-    by.set(label, [...(by.get(label) ?? []), t])
+    const key = label === null ? null : label.toLowerCase()
+    if (label !== null && !display.has(key as string)) display.set(key as string, label)
+    by.set(key, [...(by.get(key) ?? []), t])
   }
   const labels = [...by.keys()]
     .filter((l): l is string => l !== null)
     .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
   const order: (string | null)[] = by.has(null) ? [...labels, null] : labels
-  return order.map((label) => ({ label, tasks: by.get(label)! }))
+  return order.map((key) => ({
+    label: key === null ? null : (display.get(key) ?? key),
+    tasks: by.get(key)!,
+  }))
 }

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -116,3 +116,60 @@ export function groupByPeriod(
   }
   return order.filter((p) => by.has(p)).map((p) => ({ period: p, tasks: by.get(p)! }))
 }
+
+/**
+ * What a label group's header says: how many quotas, and how many are met.
+ *
+ * NOT `trackSummary`. That adds targets up, which is honest for one period and
+ * meaningless across several — "2 a day + 3 a week + 1 a month = 7" is a number
+ * nobody can act on, and a label group mixes periods by construction. Counting
+ * quotas survives the mixing, and "met" is per-quota (`trackState`), so it
+ * means the same thing in every group.
+ */
+export function quotaGroupSummary(tasks: Pick<Task, 'progress_target' | 'progress_current'>[]): {
+  count: number
+  met: number
+} {
+  return { count: tasks.length, met: tasks.filter((t) => trackState(t).met).length }
+}
+
+/** The one label a quota is filed under: the first it carries, or none. */
+export function quotaLabelOf(quota: Pick<Task, 'labels'>): string | null {
+  return quota.labels?.[0] ?? null
+}
+
+/**
+ * Quotas by label — the Quotas page's grouping (Trent, 2026-09-08: "I think we
+ * need to have one label for quotas… there's a bunch of stuff for the kids and
+ * there are other things").
+ *
+ * ONE label per quota: the editor writes a single entry, and a quota that
+ * still carries two from before that rule is filed under the FIRST — the
+ * migration deliberately left those rows alone, so this has to have an answer
+ * for them rather than putting one quota in two places.
+ *
+ * Alphabetical, with the unlabelled group last: it is the leftovers, not a
+ * name that happens to sort after "website". `sensitivity: 'base'` matches the
+ * within-group order `trackedItems` uses, so the page sorts by one rule
+ * throughout. Each group keeps the order it was given (that frozen alphabetical
+ * order), because logging on one quota must never reorder the others under the
+ * user's finger.
+ *
+ * The dashboard's Track panel deliberately still groups by PERIOD: it is an
+ * instrument for "what is left this week", where the period is the question.
+ * Here the period is on each row instead, since a label group mixes them.
+ */
+export function groupByLabel(
+  quotas: Pick<Task, 'labels'>[],
+): { label: string | null; tasks: Task[] }[] {
+  const by = new Map<string | null, Task[]>()
+  for (const t of quotas as Task[]) {
+    const label = quotaLabelOf(t)
+    by.set(label, [...(by.get(label) ?? []), t])
+  }
+  const labels = [...by.keys()]
+    .filter((l): l is string => l !== null)
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+  const order: (string | null)[] = by.has(null) ? [...labels, null] : labels
+  return order.map((label) => ({ label, tasks: by.get(label)! }))
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,6 +67,15 @@ export interface Task {
   progress_target: number
   progress_current: number
   is_tracked: boolean
+  /**
+   * §5: the UTC instant the current period began, by the user's local calendar
+   * (Monday 00:00 for a week, the 1st for a month). Written by the period
+   * rollover job — see `src/core/tasks/period-rollover.ts` — and null until it
+   * first runs for a quota. This is a quota's ONLY anchor in time: it has no
+   * `due_at`, so anything computing how far through the period a quota is (the
+   * iOS Track widget's pace tick) must read this, not a date.
+   */
+  progress_period_start: string | null
 
   /**
    * §6: this item lives on the Reminders surface — a prompted thought rather

--- a/tests/behavioral/ai-enrichment.test.ts
+++ b/tests/behavioral/ai-enrichment.test.ts
@@ -1336,3 +1336,56 @@ describe('AI activity log table', () => {
     expect(rows[0].status).toBe('success')
   })
 })
+
+/**
+ * §5, review finding 2026-09-08: enrichment writes `due_at`, `rrule` and the
+ * derived anchors with raw SQL, so it bypasses the quota guards in
+ * `collectFieldChanges` entirely. Two ways in: a user re-enriches a quota by
+ * adding `ai-to-process`, or an enrichment is in flight while the task is
+ * converted into one. `applyEnrichment` re-reads the task before writing, so
+ * the guard sits on that re-read.
+ */
+describe('enrichment leaves a quota dateless', () => {
+  beforeEach(() => clearPendingEnrichment())
+
+  test('a date and a schedule from the model are dropped on a tracked task', async () => {
+    const quota = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'eat beef four times a week', progress_target: 4, rrule: 'FREQ=WEEKLY' },
+    })
+    expect(getTaskById(quota.id)!.due_at).toBeNull()
+
+    // Re-enrichment: the user adds the trigger label back by hand.
+    getDb()
+      .prepare(
+        "UPDATE tasks SET labels = json_insert(labels, '$[#]', 'ai-to-process') WHERE id = ?",
+      )
+      .run(quota.id)
+
+    mockEnrichmentQuery.mockResolvedValueOnce(
+      mockResult({
+        title: 'Eat beef',
+        priority: 2,
+        labels: [],
+        due_at: '2026-02-20T08:00:00',
+        rrule: 'FREQ=WEEKLY;BYDAY=TU',
+        recurrence_mode: 'from_completion',
+      }),
+    )
+
+    await processEnrichmentQueue()
+
+    const after = getTaskById(quota.id)!
+    // Nothing schedule-shaped landed...
+    expect(after.due_at).toBeNull()
+    expect(after.original_due_at).toBeNull()
+    expect(after.rrule).toBe('FREQ=WEEKLY')
+    expect(after.anchor_dow).toBeNull()
+    expect(after.recurrence_mode).toBe('from_due')
+    // ...but the fields that mean the same thing on a quota still did.
+    expect(after.title).toBe('Eat beef')
+    expect(after.priority).toBe(2)
+    expect(after.labels).not.toContain('ai-to-process')
+  })
+})

--- a/tests/behavioral/export.test.ts
+++ b/tests/behavioral/export.test.ts
@@ -276,6 +276,7 @@ function makeFakeTask(overrides: Partial<FormattedTask>): FormattedTask {
     progress_target: 1,
     is_reminder: false,
     is_tracked: false,
+    progress_period_start: null,
     progress_current: 0,
     skip_count: 0,
     done: false,

--- a/tests/behavioral/format-task-clipboard.test.ts
+++ b/tests/behavioral/format-task-clipboard.test.ts
@@ -32,6 +32,7 @@ function makeTask(overrides: Partial<Task> & { id: number; title: string }): Tas
     progress_target: 1,
     is_reminder: false,
     is_tracked: false,
+    progress_period_start: null,
     progress_current: 0,
     skip_count: 0,
     priority: 0,

--- a/tests/behavioral/sk-skip.test.ts
+++ b/tests/behavioral/sk-skip.test.ts
@@ -146,8 +146,8 @@ describe('Skip occurrence', () => {
       userTimezone: TEST_TIMEZONE,
       input: {
         title: 'Eggs',
-        rrule: 'FREQ=WEEKLY;BYDAY=TH',
-        due_at: localTime(9, 0),
+        // A quota's own rule (bare period) and no due_at — §5, 2026-09-08.
+        rrule: 'FREQ=WEEKLY',
         progress_target: 2,
       },
     })
@@ -156,6 +156,8 @@ describe('Skip occurrence', () => {
 
     skipOccurrence({ userId: TEST_USER_ID, userTimezone: TEST_TIMEZONE, taskId: task.id })
     expect(getTaskById(task.id)!.progress_current).toBe(0)
+    // The skip is a period boundary, not a date move: a quota has no date.
+    expect(getTaskById(task.id)!.due_at).toBeNull()
   })
 
   /**

--- a/tests/behavioral/tk-track.test.ts
+++ b/tests/behavioral/tk-track.test.ts
@@ -119,7 +119,9 @@ describe('Track (quotas)', () => {
    * period rolling over.
    */
   test('TK-007: completing a recurring tracked task resets progress at the boundary', () => {
-    const task = makeTracked(2, { rrule: 'FREQ=WEEKLY;BYDAY=TH', due_at: localTime(9, 0) })
+    // A bare period rule, which is what the corpus actually holds — and with
+    // no due_at, because a quota has none (§5, 2026-09-08).
+    const task = makeTracked(2, { rrule: 'FREQ=WEEKLY' })
     incrementProgress({ userId: TEST_USER_ID, taskId: task.id })
     incrementProgress({ userId: TEST_USER_ID, taskId: task.id })
     expect(getTaskById(task.id)!.progress_current).toBe(2)
@@ -131,6 +133,8 @@ describe('Track (quotas)', () => {
     expect(after.completion_count).toBe(1)
     // Still open — recurring tasks advance rather than closing.
     expect(after.done).toBe(false)
+    // The boundary advanced nothing: there is no occurrence to move.
+    expect(after.due_at).toBeNull()
   })
 
   /**
@@ -233,7 +237,9 @@ describe('Track (quotas)', () => {
       userTimezone: TEST_TIMEZONE,
       input: { title: 'Plain overdue', due_at: localTime(8, 0) },
     })
-    const tracked = makeTracked(2, { due_at: localTime(8, 0) })
+    // A quota has no due_at at all now, so it is doubly excluded: by the
+    // `is_tracked = 0` clause and by having no date to be due at.
+    const tracked = makeTracked(2)
 
     const due = getCurrentlyDueTaskIds(TEST_USER_ID)
     expect(due).toContain(plain.id)

--- a/tests/behavioral/tr-quota-labels.test.ts
+++ b/tests/behavioral/tr-quota-labels.test.ts
@@ -1,0 +1,112 @@
+/**
+ * One label per quota, and the Quotas page's grouping by it (§5).
+ *
+ * Trent, 2026-09-08: "I think we need to have one label for quotas… there's a
+ * bunch of stuff for the kids and there are other things." The editor writes a
+ * single label from then on, but the corpus still holds quotas carrying two
+ * (the migration deliberately left them alone), so "one label" has to be a rule
+ * the READER enforces as well: the first entry wins, and a quota appears in
+ * exactly one group.
+ *
+ * Pure functions over plain objects — no database, no clock, so nothing here
+ * depends on when it runs.
+ */
+import { describe, test, expect } from 'vitest'
+import { groupByLabel, quotaLabelOf, quotaGroupSummary } from '@/lib/track'
+import type { Task } from '@/types'
+
+const quota = (title: string, labels: string[], progress?: [number, number]): Task =>
+  ({
+    title,
+    labels,
+    progress_current: progress?.[0] ?? 0,
+    progress_target: progress?.[1] ?? 3,
+  }) as Task
+
+describe('a quota has one label', () => {
+  test('the first label wins when a quota still carries two', () => {
+    // Six quotas on the real corpus look like this — e.g. ["health","kids"].
+    expect(quotaLabelOf(quota('Kids Smoothie', ['health', 'kids']))).toBe('health')
+    const groups = groupByLabel([quota('Kids Smoothie', ['health', 'kids'])])
+    expect(groups.map((g) => g.label)).toEqual(['health'])
+    expect(groups).toHaveLength(1)
+  })
+
+  test('no labels at all is a group, not a missing one', () => {
+    expect(quotaLabelOf(quota('Eggs', []))).toBeNull()
+    expect(groupByLabel([quota('Eggs', [])]).map((g) => g.label)).toEqual([null])
+  })
+})
+
+describe('grouping quotas by label', () => {
+  test('groups are alphabetical and the unlabelled one is last', () => {
+    const groups = groupByLabel([
+      quota('Weight Lift', ['health']),
+      quota('Eggs', []),
+      quota('Clean bedroom fans', ['house']),
+      quota('Check for certifications', ['job-hunt']),
+      quota('Clean car seat', ['kids', 'house']),
+      quota('Broccoli Avocado', []),
+    ])
+    // Not sorted-with-null-in-place: "unlabelled" is the leftovers, so it goes
+    // last however the names happen to sort.
+    expect(groups.map((g) => g.label)).toEqual(['health', 'house', 'job-hunt', 'kids', null])
+    expect(groups.map((g) => g.tasks.length)).toEqual([1, 1, 1, 1, 2])
+  })
+
+  test('case does not split or reorder a group', () => {
+    const groups = groupByLabel([quota('B', ['Health']), quota('A', ['house'])])
+    expect(groups.map((g) => g.label)).toEqual(['Health', 'house'])
+  })
+
+  test('every quota lands in exactly one group', () => {
+    const quotas = [
+      quota('a', ['health', 'kids']),
+      quota('b', ['kids', 'house']),
+      quota('c', []),
+      quota('d', ['health']),
+    ]
+    const groups = groupByLabel(quotas)
+    expect(groups.flatMap((g) => g.tasks)).toHaveLength(quotas.length)
+    expect(new Set(groups.flatMap((g) => g.tasks.map((t) => t.title))).size).toBe(quotas.length)
+  })
+
+  test('within a group the given order is kept, untouched', () => {
+    // The page hands these over already sorted by title (`trackedItems`), and
+    // that order is FROZEN: a +1 must never move a row under the user's finger
+    // (commit 9bcf03d). Grouping is not allowed to re-sort them.
+    const groups = groupByLabel([
+      quota('Cook daily vegetables', ['health'], [5, 5]),
+      quota('Daily Walks', ['health'], [0, 2]),
+      quota('Kids Smoothie', ['health', 'kids']),
+      quota('Weight Lift', ['health'], [1, 3]),
+    ])
+    expect(groups[0].tasks.map((t) => t.title)).toEqual([
+      'Cook daily vegetables',
+      'Daily Walks',
+      'Kids Smoothie',
+      'Weight Lift',
+    ])
+  })
+
+  test('nothing in, nothing out', () => {
+    expect(groupByLabel([])).toEqual([])
+  })
+})
+
+describe("a label group's header numbers", () => {
+  test('counts quotas and met quotas, and never sums mixed targets', () => {
+    const group = [
+      quota('Cook daily vegetables', ['health'], [5, 5]), // met
+      quota('Daily Walks', ['health'], [3, 2]), // met, and over
+      quota('Weight Lift', ['health'], [1, 3]),
+    ]
+    // "3 quotas · 2 met" — not "9 of 10", which would add a weekly target to a
+    // daily one and to a monthly one and mean nothing.
+    expect(quotaGroupSummary(group)).toEqual({ count: 3, met: 2 })
+  })
+
+  test('a group nobody has logged yet reports zero met', () => {
+    expect(quotaGroupSummary([quota('Eggs', [], [0, 2])])).toEqual({ count: 1, met: 0 })
+  })
+})

--- a/tests/behavioral/tr-quota-labels.test.ts
+++ b/tests/behavioral/tr-quota-labels.test.ts
@@ -54,9 +54,46 @@ describe('grouping quotas by label', () => {
     expect(groups.map((g) => g.tasks.length)).toEqual([1, 1, 1, 1, 2])
   })
 
-  test('case does not split or reorder a group', () => {
+  test('case does not split a group — "Kids" and "kids" are one', () => {
+    // The registry's UNIQUE is case-sensitive, so both spellings can exist and
+    // both can end up on quotas. Grouping by the raw string drew two cards
+    // whose headers both read "KIDS". The FIRST spelling seen names the group.
+    //
+    // This test used to pass `Health` and `house` — two different labels — so
+    // it asserted nothing about case despite its name.
+    const groups = groupByLabel([quota('B', ['Kids']), quota('A', ['kids']), quota('C', ['KIDS'])])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].label).toBe('Kids')
+    expect(groups[0].tasks.map((t) => t.title)).toEqual(['B', 'A', 'C'])
+  })
+
+  test('different labels still sort into different groups, case regardless', () => {
+    // The coverage the old test actually had, kept: case-insensitive KEYING
+    // must not collapse distinct names or disturb the alphabetical order.
     const groups = groupByLabel([quota('B', ['Health']), quota('A', ['house'])])
     expect(groups.map((g) => g.label)).toEqual(['Health', 'house'])
+  })
+
+  /**
+   * Second review, finding 2. `ai-*` labels are machinery — `createTask`
+   * appends `ai-to-process`/`ai-proposed`/`ai-added`, enrichment writes
+   * `ai-failed` — and a quota carrying one is not filed under it. Taking
+   * `labels[0]` blindly gave a group header reading "AI-FAILED".
+   */
+  test('an operational label is never the label a quota is filed under', () => {
+    expect(quotaLabelOf(quota('Eggs', ['ai-added', 'kids']))).toBe('kids')
+    expect(quotaLabelOf(quota('Eggs', ['ai-failed']))).toBeNull()
+    expect(quotaLabelOf(quota('Eggs', ['ai-to-process', 'ai-proposed']))).toBeNull()
+
+    const groups = groupByLabel([
+      quota('Freshly created', ['ai-to-process']),
+      quota('Enriched and filed', ['ai-added', 'kids']),
+      quota('Plain', ['kids']),
+    ])
+    // One real group, and the machinery-only quota is unlabelled — not a group
+    // of its own called "ai-to-process".
+    expect(groups.map((g) => g.label)).toEqual(['kids', null])
+    expect(groups.map((g) => g.tasks.length)).toEqual([2, 1])
   })
 
   test('every quota lands in exactly one group', () => {

--- a/tests/behavioral/tr-quota-no-date.test.ts
+++ b/tests/behavioral/tr-quota-no-date.test.ts
@@ -361,7 +361,12 @@ describe('A quota is not a task — the other paths the first cut missed', () =>
     expect(after.rrule).toBeNull()
     expect(after.due_at).toBe(when)
     expect(after.snooze_count).toBe(0)
-    expect(after.original_due_at).toBe(before.original_due_at)
+    // The occurrence origin went with the old schedule, so nothing reads this
+    // row as snoozed: `is_snoozed` in the API response is
+    // `original_due_at !== null`, and the row's snoozed indicator is the same
+    // test. A task created recurring has this set to its first occurrence, so
+    // leaving it behind drew the indicator on a plain re-schedule.
+    expect(after.original_due_at).toBeNull()
     expect(description).not.toMatch(/snooz/i)
   })
 

--- a/tests/behavioral/tr-quota-no-date.test.ts
+++ b/tests/behavioral/tr-quota-no-date.test.ts
@@ -1,0 +1,230 @@
+/**
+ * TR-010..019: a quota is not a task (REDESIGN-V03 §5, Trent 2026-09-08).
+ *
+ * It appears on the Quotas page and in the Track panel and nowhere else, it has
+ * no due date, and it cannot be snoozed. `due_at` on a quota was vestigial —
+ * the period is carried by `progress_period_start` — but it was still a real
+ * date, so a quota read as overdue debt in every count and offered a snooze
+ * grid it could not honour.
+ *
+ * The sibling to compare against is the reminder carve-out (§6), which these
+ * rules are deliberately shaped like.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createTask, getTaskById, updateTask, snoozeTask, bulkEdit } from '@/core/tasks'
+import { clearQuotaDueDates, getDb } from '@/core/db'
+import { ValidationError } from '@/core/errors'
+import { QUOTA_DUE_DATE_MESSAGE } from '@/core/validation'
+import { effectiveDueAt } from '@/core/recurrence/occurrence'
+import { isTracked } from '@/lib/track'
+import { countTasks } from '@/lib/task-counts'
+import { setupTestDb, teardownTestDb, TEST_TIMEZONE, TEST_USER_ID } from '../helpers/setup'
+
+/** Frozen so "tomorrow" and "this week" mean the same thing on every run. */
+const NOW = new Date('2026-01-15T16:00:00Z')
+
+function makeQuota(overrides: Record<string, unknown> = {}) {
+  return createTask({
+    userId: TEST_USER_ID,
+    userTimezone: TEST_TIMEZONE,
+    input: { title: 'Eat beef', rrule: 'FREQ=WEEKLY', progress_target: 4, ...overrides },
+  })
+}
+
+describe('A quota has no due date', () => {
+  beforeEach(() => {
+    vi.setSystemTime(NOW)
+    setupTestDb()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    teardownTestDb()
+  })
+
+  test('TR-010: creating a quota never stamps a due date', () => {
+    const byTarget = makeQuota()
+    expect(getTaskById(byTarget.id)!.due_at).toBeNull()
+    expect(getTaskById(byTarget.id)!.original_due_at).toBeNull()
+
+    // The other way of being a quota: an explicit flag with a target of 1.
+    const byFlag = makeQuota({
+      title: 'Date night',
+      rrule: 'FREQ=MONTHLY',
+      progress_target: 1,
+      is_tracked: true,
+    })
+    expect(getTaskById(byFlag.id)!.due_at).toBeNull()
+
+    // With no rule at all there is nothing to compute from either.
+    const ruleless = makeQuota({ title: 'Read', rrule: null })
+    expect(getTaskById(ruleless.id)!.due_at).toBeNull()
+  })
+
+  test('TR-011: an ordinary recurring task still gets its first occurrence', () => {
+    const task = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Water the plants', rrule: 'FREQ=WEEKLY;BYDAY=MO' },
+    })
+    // The guard is narrow: only tracked rows lose the computed date.
+    expect(getTaskById(task.id)!.due_at).not.toBeNull()
+  })
+
+  test('TR-012: a due date cannot be given to a quota, at create or at update', () => {
+    expect(() => makeQuota({ due_at: NOW.toISOString() })).toThrow(ValidationError)
+    expect(() => makeQuota({ due_at: NOW.toISOString() })).toThrow(QUOTA_DUE_DATE_MESSAGE)
+
+    const quota = makeQuota()
+    expect(() =>
+      updateTask({
+        userId: TEST_USER_ID,
+        userTimezone: TEST_TIMEZONE,
+        taskId: quota.id,
+        input: { due_at: NOW.toISOString() },
+      }),
+    ).toThrow(QUOTA_DUE_DATE_MESSAGE)
+
+    // Converting a task into a quota in the same request that dates it is the
+    // same contradiction, and is refused the same way.
+    const plain = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Call mom' },
+    })
+    expect(() =>
+      updateTask({
+        userId: TEST_USER_ID,
+        userTimezone: TEST_TIMEZONE,
+        taskId: plain.id,
+        input: { is_tracked: true, due_at: NOW.toISOString() },
+      }),
+    ).toThrow(QUOTA_DUE_DATE_MESSAGE)
+  })
+
+  test('TR-013: converting a dated task into a quota clears its date', () => {
+    const plain = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Go for a walk', due_at: NOW.toISOString() },
+    })
+    expect(getTaskById(plain.id)!.due_at).not.toBeNull()
+
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: plain.id,
+      input: { is_tracked: true, progress_target: 3, rrule: 'FREQ=WEEKLY' },
+    })
+
+    const after = getTaskById(plain.id)!
+    expect(isTracked(after)).toBe(true)
+    expect(after.due_at).toBeNull()
+    // `original_due_at` goes too, or `is_snoozed` stays true on a row that
+    // cannot be snoozed.
+    expect(after.original_due_at).toBeNull()
+  })
+
+  test('TR-014: a quota cannot be snoozed', () => {
+    const quota = makeQuota()
+    expect(() =>
+      snoozeTask({
+        userId: TEST_USER_ID,
+        userTimezone: TEST_TIMEZONE,
+        taskId: quota.id,
+        until: new Date(NOW.getTime() + 3_600_000).toISOString(),
+      }),
+    ).toThrow(ValidationError)
+  })
+
+  test('TR-015: retiring a quota takes its period rule with it', () => {
+    const quota = makeQuota()
+    expect(getTaskById(quota.id)!.rrule).toBe('FREQ=WEEKLY')
+
+    // `is_tracked: false` alone. A bare FREQ left behind on an untracked task
+    // with no due_at is evaluated as a schedule, and rrule.js places a bare
+    // weekly rule on an arbitrary weekday — the task would surface on a day
+    // nobody chose.
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: quota.id,
+      input: { is_tracked: false, progress_target: 1 },
+    })
+
+    const retired = getTaskById(quota.id)!
+    expect(isTracked(retired)).toBe(false)
+    expect(retired.rrule).toBeNull()
+    expect(retired.anchor_time).toBeNull()
+    expect(retired.anchor_dow).toBeNull()
+    expect(effectiveDueAt(retired, TEST_TIMEZONE, NOW)).toBeNull()
+  })
+
+  test('TR-016: retiring a quota and dating it in one request keeps the date', () => {
+    const quota = makeQuota()
+    const when = new Date(NOW.getTime() + 86_400_000).toISOString()
+
+    // Retiring injects `rrule: null`, which makes this look to the collector
+    // like a schedule change — the path that otherwise drops an explicit date.
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: quota.id,
+      input: { is_tracked: false, progress_target: 1, due_at: when },
+    })
+
+    const after = getTaskById(quota.id)!
+    expect(isTracked(after)).toBe(false)
+    expect(after.rrule).toBeNull()
+    expect(after.due_at).toBe(when)
+  })
+
+  test('TR-017: bulk edit retires a quota the same way', () => {
+    const one = makeQuota({ title: 'Quota one' })
+    const two = makeQuota({ title: 'Quota two' })
+
+    bulkEdit({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskIds: [one.id, two.id],
+      changes: { is_tracked: false, progress_target: 1 },
+    })
+
+    for (const id of [one.id, two.id]) {
+      const after = getTaskById(id)!
+      expect(isTracked(after)).toBe(false)
+      expect(after.rrule).toBeNull()
+    }
+  })
+
+  test('TR-018: the startup migration clears stored quota dates, idempotently', () => {
+    const quota = makeQuota()
+    // Write a date straight past the core, the way the pre-2026-09-08 corpus
+    // holds one: every quota carried a leftover from the life it had before.
+    getDb()
+      .prepare('UPDATE tasks SET due_at = ?, original_due_at = ? WHERE id = ?')
+      .run(NOW.toISOString(), NOW.toISOString(), quota.id)
+    const plain = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Untracked', due_at: NOW.toISOString() },
+    })
+
+    clearQuotaDueDates(getDb())
+    expect(getTaskById(quota.id)!.due_at).toBeNull()
+    expect(getTaskById(quota.id)!.original_due_at).toBeNull()
+    // It touches quotas only.
+    expect(getTaskById(plain.id)!.due_at).toBe(NOW.toISOString())
+
+    // Second run changes nothing.
+    clearQuotaDueDates(getDb())
+    expect(getTaskById(quota.id)!.due_at).toBeNull()
+    expect(getTaskById(plain.id)!.due_at).toBe(NOW.toISOString())
+  })
+
+  test('TR-019: with no date, a quota cannot reach the counts at all', () => {
+    const quota = makeQuota()
+    const stored = getTaskById(quota.id)!
+    // Two independent reasons now: no due_at, and the explicit tracked guard.
+    expect(countTasks([stored], TEST_TIMEZONE, NOW)).toEqual({ total: 1, overdue: 0, today: 0 })
+  })
+})

--- a/tests/behavioral/tr-quota-no-date.test.ts
+++ b/tests/behavioral/tr-quota-no-date.test.ts
@@ -458,10 +458,151 @@ describe('A quota is not a task — the other paths the first cut missed', () =>
     // The stat the leak inflated: one undated task, not three.
     expect(built.stats.undated).toBe(1)
   })
+})
+
+/**
+ * Second review, 2026-09-08 — the two findings that are regressions from the
+ * FIRST round of fixes, not from the original change. Hoisting "clear the
+ * occurrence origin when the rrule changes" out of its branch was too wide.
+ */
+describe('The occurrence origin survives what it should', () => {
+  beforeEach(() => {
+    vi.setSystemTime(NOW)
+    setupTestDb()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    teardownTestDb()
+  })
 
   /**
-   * Finding 3. The iOS Track widget's pace tick read `due_at`; with the date
-   * gone it needs the real anchor, which was exposed nowhere.
+   * Finding 5 — a regression from the previous commit. Hoisting
+   * "clear the occurrence origin when the rrule changes" out of the
+   * new-schedule branch applied it to EVERY rrule change, including clearing
+   * the rule on a genuinely snoozed task.
+   */
+  test('TR-027: dropping the rule alone leaves a snoozed task its snooze', () => {
+    const task = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Weekly report', rrule: 'FREQ=WEEKLY;BYDAY=MO' },
+    })
+    // Genuinely snoozed, twice, so the origin is a real pre-snooze date rather
+    // than the create-time first occurrence.
+    for (const days of [1, 2]) {
+      snoozeTask({
+        userId: TEST_USER_ID,
+        userTimezone: TEST_TIMEZONE,
+        taskId: task.id,
+        until: new Date(NOW.getTime() + days * 86_400_000).toISOString(),
+      })
+    }
+    const before = getTaskById(task.id)!
+    expect(before.snooze_count).toBe(2)
+    expect(before.original_due_at).not.toBeNull()
+
+    // The rule alone. Nothing here says anything about the date.
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: task.id,
+      input: { rrule: null },
+    })
+
+    const after = getTaskById(task.id)!
+    expect(after.rrule).toBeNull()
+    // The deferral survives: the row keeps its stripe and "snoozed from", and
+    // the quick panel's age anchor stays on the origin instead of jumping back
+    // to created_at.
+    expect(after.original_due_at).toBe(before.original_due_at)
+    expect(after.snooze_count).toBe(2)
+    expect(after.due_at).toBe(before.due_at)
+  })
+
+  test('TR-028: changing to a new rule still drops the old origin', () => {
+    const task = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Weekly report', rrule: 'FREQ=WEEKLY;BYDAY=MO' },
+    })
+    snoozeTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: task.id,
+      until: new Date(NOW.getTime() + 86_400_000).toISOString(),
+    })
+    expect(getTaskById(task.id)!.original_due_at).not.toBeNull()
+
+    // A NEW schedule: the old occurrence origin means nothing under it. This is
+    // the behaviour that predates the whole PR and must not be lost.
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: task.id,
+      input: { rrule: 'FREQ=DAILY' },
+    })
+    expect(getTaskById(task.id)!.original_due_at).toBeNull()
+  })
+
+  /**
+   * Finding 4 — also a regression from the previous commit.
+   * `collectBasicFields` pushes the reset first and the hoisted block pushed
+   * `original_due_at = NULL` after it; SQLite takes the last clause, so the
+   * user's explicit reset lost. Reachable from the quick panel, which batches
+   * "Reset origin to current due date" with the recurrence picker.
+   */
+  test('TR-029: an explicit origin reset beats the rrule change in the same PATCH', () => {
+    const task = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Weekly report', rrule: 'FREQ=WEEKLY;BYDAY=MO' },
+    })
+    snoozeTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: task.id,
+      until: new Date(NOW.getTime() + 86_400_000).toISOString(),
+    })
+    const dueAt = getTaskById(task.id)!.due_at
+
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: task.id,
+      input: { reset_original_due_at: true, rrule: null },
+    })
+
+    const after = getTaskById(task.id)!
+    // "The origin IS the current due date" — said explicitly, so it wins.
+    expect(after.original_due_at).toBe(dueAt)
+    expect(after.snooze_count).toBe(0)
+
+    // The same holds when the rule changes to a NEW value, which was already
+    // overridden before any of this PR's changes.
+    const other = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Another', rrule: 'FREQ=WEEKLY;BYDAY=MO' },
+    })
+    snoozeTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: other.id,
+      until: new Date(NOW.getTime() + 86_400_000).toISOString(),
+    })
+    const otherDue = getTaskById(other.id)!.due_at
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: other.id,
+      input: { reset_original_due_at: true, rrule: 'FREQ=DAILY' },
+    })
+    expect(getTaskById(other.id)!.original_due_at).toBe(otherDue)
+  })
+
+  /**
+   * Round-one finding 3. The iOS Track widget's pace tick read `due_at`; with
+   * the date gone it needs the real anchor, which was exposed nowhere.
    */
   test('TR-026: a quota carries its period anchor in the task shape', () => {
     const quota = makeQuota()

--- a/tests/behavioral/tr-quota-no-date.test.ts
+++ b/tests/behavioral/tr-quota-no-date.test.ts
@@ -12,6 +12,8 @@
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createTask, getTaskById, updateTask, snoozeTask, bulkEdit } from '@/core/tasks'
+import { executeUndo, executeRedo } from '@/core/undo'
+import { buildFromDb } from '@/core/ai/quick-take'
 import { clearQuotaDueDates, getDb } from '@/core/db'
 import { ValidationError } from '@/core/errors'
 import { QUOTA_DUE_DATE_MESSAGE } from '@/core/validation'
@@ -226,5 +228,246 @@ describe('A quota has no due date', () => {
     const stored = getTaskById(quota.id)!
     // Two independent reasons now: no due_at, and the explicit tracked guard.
     expect(countTasks([stored], TEST_TIMEZONE, NOW)).toEqual({ total: 1, overdue: 0, today: 0 })
+  })
+})
+
+/**
+ * Review finding 1, 2026-09-08 (HIGH). `is_tracked` was missing from undo's
+ * column allowlist. Its own block because undo has its own failure mode: the
+ * allowlist THROWS rather than skipping, and the throw takes the whole
+ * transaction with it.
+ */
+describe('Undo and redo of a quota flag', () => {
+  beforeEach(() => {
+    vi.setSystemTime(NOW)
+    setupTestDb()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    teardownTestDb()
+  })
+
+  /**
+   * `undoEntry` runs inside the caller's transaction, so the throw rolled back
+   * the `undone = 1` write too: the entry stayed unconsumed and every later
+   * Undo found it again — one retire wedged the whole stack.
+   *
+   * Every quota in the tests above was created with `progress_target` alone, so
+   * `is_tracked` never entered `fieldsChanged` and none of them reached this.
+   */
+  test('TR-020: retiring a quota with an explicit flag can be undone and redone', () => {
+    const quota = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      // The flag EXPLICITLY, so retiring it puts `is_tracked` in fieldsChanged.
+      input: { title: 'Date night', rrule: 'FREQ=MONTHLY', is_tracked: true },
+    })
+
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: quota.id,
+      input: { is_tracked: false },
+    })
+    expect(getTaskById(quota.id)!.is_tracked).toBe(false)
+    expect(getTaskById(quota.id)!.rrule).toBeNull()
+
+    expect(() => executeUndo(TEST_USER_ID)).not.toThrow()
+    const undone = getTaskById(quota.id)!
+    expect(undone.is_tracked).toBe(true)
+    // The rule rides in the same fieldsChanged, so a throw on `is_tracked`
+    // took the rrule's restoration down with it.
+    expect(undone.rrule).toBe('FREQ=MONTHLY')
+
+    expect(() => executeRedo(TEST_USER_ID)).not.toThrow()
+    const redone = getTaskById(quota.id)!
+    expect(redone.is_tracked).toBe(false)
+    expect(redone.rrule).toBeNull()
+  })
+
+  test('TR-021: the editor path (0 → 1) undoes, and the stack is not wedged', () => {
+    // What QuotaDetail.buildChanges sends whenever the target or period is
+    // touched: `is_tracked: true` on a row whose column is still 0.
+    const quota = makeQuota({ title: 'Eggs' })
+    expect(getTaskById(quota.id)!.is_tracked).toBe(false)
+
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: quota.id,
+      input: { is_tracked: true, progress_target: 5 },
+    })
+    expect(getTaskById(quota.id)!.is_tracked).toBe(true)
+
+    // A second, unrelated action on top, so the failing entry is not the only
+    // one on the stack — this is what "wedges" means: the throw leaves the
+    // entry at undone = 0 and every later Undo lands on it again.
+    updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: quota.id,
+      input: { title: 'Eggs for the kids' },
+    })
+
+    expect(() => executeUndo(TEST_USER_ID)).not.toThrow()
+    expect(getTaskById(quota.id)!.title).toBe('Eggs')
+    expect(() => executeUndo(TEST_USER_ID)).not.toThrow()
+    const after = getTaskById(quota.id)!
+    expect(after.is_tracked).toBe(false)
+    expect(after.progress_target).toBe(4)
+  })
+})
+
+/**
+ * Review findings 2, 3, 4 and 6, 2026-09-08 — each a path the first cut of "a
+ * quota is not a task" missed, found by a fresh-eyes pass over that change.
+ */
+describe('A quota is not a task — the other paths the first cut missed', () => {
+  beforeEach(() => {
+    vi.setSystemTime(NOW)
+    setupTestDb()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    teardownTestDb()
+  })
+
+  /**
+   * Finding 4. Widening the rrule-changed guard to "any explicit date" fixed a
+   * dropped date but let `{ rrule: null, due_at: X }` — the quick panel's
+   * "clear recurrence and pick a date" — fall into the snooze branch. A
+   * re-schedule is not a deferral.
+   */
+  test('TR-022: clearing recurrence while setting a date is not a snooze', () => {
+    const task = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      // Must already HAVE a date: the snooze branch only fires when it does.
+      input: { title: 'Weekly report', rrule: 'FREQ=WEEKLY;BYDAY=MO' },
+    })
+    const before = getTaskById(task.id)!
+    expect(before.due_at).not.toBeNull()
+    expect(before.snooze_count).toBe(0)
+
+    const when = new Date(NOW.getTime() + 86_400_000).toISOString()
+    const { description } = updateTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskId: task.id,
+      input: { rrule: null, due_at: when },
+    })
+
+    const after = getTaskById(task.id)!
+    expect(after.rrule).toBeNull()
+    expect(after.due_at).toBe(when)
+    expect(after.snooze_count).toBe(0)
+    expect(after.original_due_at).toBe(before.original_due_at)
+    expect(description).not.toMatch(/snooz/i)
+  })
+
+  /**
+   * Finding 6. A date-bearing bulk edit hit `collectFieldChanges`' refusal on a
+   * quota, and one throw aborts the whole transaction — the reviewer's probe
+   * lost a sibling task's priority edit. Skip the quota, keep the batch.
+   */
+  test('TR-023: a bulk edit carrying a date skips quotas instead of losing the batch', () => {
+    const quota = makeQuota({ title: 'Quota in the selection' })
+    const plain = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Plain sibling', due_at: NOW.toISOString() },
+    })
+    const when = new Date(NOW.getTime() + 86_400_000).toISOString()
+
+    // `{ due_at, rrule }` together — the shape the snooze filter never saw,
+    // because it only runs when rrule is absent.
+    const result = bulkEdit({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskIds: [quota.id, plain.id],
+      changes: { due_at: when, rrule: null, priority: 2 },
+    })
+
+    expect(result.tasksAffected).toBe(1)
+    expect(result.tasksSkipped).toBe(1)
+    // The sibling's edit survived...
+    const plainAfter = getTaskById(plain.id)!
+    expect(plainAfter.due_at).toBe(when)
+    expect(plainAfter.priority).toBe(2)
+    // ...and the quota is untouched, still dateless.
+    const quotaAfter = getTaskById(quota.id)!
+    expect(quotaAfter.due_at).toBeNull()
+    expect(quotaAfter.priority).toBe(0)
+  })
+
+  test('TR-024: a per-task date does not lose the batch either', () => {
+    const quota = makeQuota({ title: 'Quota with a per-task date' })
+    const plain = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'Plain sibling' },
+    })
+    const when = new Date(NOW.getTime() + 86_400_000).toISOString()
+
+    // Only reachable from core: `bulkEditSchema.per_task` is `.strict()` on
+    // `{ rrule }`, so the route rejects a per-task `due_at` before it gets
+    // here. Pinned anyway — the guard is in core, and the schema could widen.
+    const result = bulkEdit({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      taskIds: [quota.id, plain.id],
+      changes: { priority: 3 },
+      perTask: { [String(quota.id)]: { due_at: when } as { due_at: string } },
+    })
+
+    expect(result.tasksAffected).toBe(1)
+    expect(result.tasksSkipped).toBe(1)
+    expect(getTaskById(plain.id)!.priority).toBe(3)
+    expect(getTaskById(quota.id)!.due_at).toBeNull()
+  })
+
+  /**
+   * Finding 2. Quick Take read the whole open corpus. With quotas now undated
+   * every one of them landed in the `undated` stat and was named in the
+   * compact list as a task to do.
+   */
+  test('TR-025: Quick Take is not shown quotas or reminders', () => {
+    const plain = createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'A real undated task' },
+    })
+    makeQuota({ title: 'Eat beef' })
+    createTask({
+      userId: TEST_USER_ID,
+      userTimezone: TEST_TIMEZONE,
+      input: { title: 'A reminder', is_reminder: true },
+    })
+
+    const built = buildFromDb(TEST_USER_ID, TEST_TIMEZONE)
+
+    expect(built.count).toBe(1)
+    expect(built.tasks.map((t) => t.title)).toEqual([plain.title])
+    expect(built.text).not.toContain('Eat beef')
+    expect(built.text).not.toContain('A reminder')
+    // The stat the leak inflated: one undated task, not three.
+    expect(built.stats.undated).toBe(1)
+  })
+
+  /**
+   * Finding 3. The iOS Track widget's pace tick read `due_at`; with the date
+   * gone it needs the real anchor, which was exposed nowhere.
+   */
+  test('TR-026: a quota carries its period anchor in the task shape', () => {
+    const quota = makeQuota()
+    const stored = getTaskById(quota.id)!
+    // Null until the rollover job first anchors it — but present, and typed.
+    expect(stored).toHaveProperty('progress_period_start')
+    expect(stored.progress_period_start).toBeNull()
+
+    getDb()
+      .prepare('UPDATE tasks SET progress_period_start = ? WHERE id = ?')
+      .run('2026-01-12T06:00:00.000Z', quota.id)
+    expect(getTaskById(quota.id)!.progress_period_start).toBe('2026-01-12T06:00:00.000Z')
   })
 })

--- a/tests/behavioral/tr-tracked-flag.test.ts
+++ b/tests/behavioral/tr-tracked-flag.test.ts
@@ -69,15 +69,13 @@ describe('Tracked flag', () => {
     const night = createTask({
       userId: TEST_USER_ID,
       userTimezone: TEST_TIMEZONE,
-      input: {
-        title: 'Date night',
-        rrule: 'FREQ=MONTHLY',
-        is_tracked: true,
-        due_at: NOW.toISOString(),
-      },
+      // No due_at: a quota has none (§5, 2026-09-08) and creating one with a
+      // date is refused — see tr-quota-no-date.test.ts.
+      input: { title: 'Date night', rrule: 'FREQ=MONTHLY', is_tracked: true },
     })
     const stored = getTaskById(night.id)!
     expect(stored.is_tracked).toBe(true)
+    expect(stored.due_at).toBeNull()
     expect(stored.progress_target).toBe(1)
     expect(isTracked(stored)).toBe(true)
 

--- a/tests/e2e/track.spec.ts
+++ b/tests/e2e/track.spec.ts
@@ -421,6 +421,12 @@ test.describe('Quotas page', () => {
         rrule: 'FREQ=WEEKLY',
       })
       ids.push(retireId)
+      // Reload rather than waiting for the row to be pushed in. This quota was
+      // made through the API, so the only thing that would bring it to a page
+      // already open is the sync stream — and asserting on a push makes the
+      // test depend on delivery timing rather than on server state. Same for
+      // the reload after the undo below.
+      await page.reload()
       await expect(page.locator(`[data-quota-row="${retireId}"]`)).toBeVisible()
 
       const retired = await page.request.patch(`/api/tasks/${retireId}`, {
@@ -431,8 +437,8 @@ test.describe('Quotas page', () => {
       expect(retiredBody.is_tracked).toBe(false)
       expect(retiredBody.rrule).toBeNull()
       expect(retiredBody.due_at).toBeNull()
-      // It is no longer a quota, so it leaves this page — which is also how we
-      // know the refresh has landed, rather than by waiting a fixed time.
+      // It is no longer a quota, so it leaves this page.
+      await page.reload()
       await expect(page.locator(`[data-quota-row="${retireId}"]`)).toHaveCount(0)
 
       // Undo puts it back, flag and rule together. This is the path that used
@@ -440,6 +446,7 @@ test.describe('Quotas page', () => {
       // (`is_tracked` was not on it), so a green 200 here is the contract.
       const undone = await page.request.post('/api/undo')
       expect(undone.status()).toBe(200)
+      await page.reload()
       await expect(page.locator(`[data-quota-row="${retireId}"]`)).toBeVisible()
 
       // And a quota refuses a snooze outright (§5/A4).
@@ -581,6 +588,71 @@ test.describe('Quota labels', () => {
       await expect(
         view.locator(`[data-quota-group="probe-domain"] [data-quota-row="${newId}"]`),
       ).toHaveCount(1)
+    } finally {
+      await deleteTasks(page, ids)
+    }
+  })
+
+  /**
+   * Second review finding 1: a label typed while editing SEVERAL quotas goes
+   * through `POST /api/tasks/bulk/edit`, which writes `labels` as raw SQL and
+   * never registered the name. Both rows carried it and the registry had never
+   * heard of it, so the NEXT editor did not offer the chip — which is what this
+   * asserts, by opening a third quota that was never part of the selection.
+   */
+  test('a new label typed while editing several quotas reaches the registry', async ({
+    authenticatedPage: page,
+  }) => {
+    const ids: number[] = []
+    const fresh = `probe-bulk-${Date.now()}`
+    try {
+      for (const title of [
+        'Probe bulk label one',
+        'Probe bulk label two',
+        'Probe bulk label third',
+      ]) {
+        ids.push(await createTask(page, { title, progress_target: 2, rrule: 'FREQ=WEEKLY' }))
+      }
+
+      await page.goto('/quotas')
+      const view = page.locator('[data-quotas-view]')
+      await expect(view).toBeVisible()
+
+      // Two selected → the bulk endpoint.
+      await view.locator(`[data-quota-row="${ids[0]}"]`).click()
+      await view.locator(`[data-quota-row="${ids[1]}"]`).click({ modifiers: ['Shift'] })
+      const bar = page.locator('[data-quota-selection-bar]')
+      await bar.getByRole('button', { name: 'Details' }).click()
+
+      const editor = page.getByRole('dialog')
+      await expect(editor).toBeVisible()
+      await editor.getByRole('button', { name: '+ New' }).click()
+      await editor.getByRole('textbox', { name: 'New label' }).fill(fresh)
+      await editor.getByRole('textbox', { name: 'New label' }).press('Enter')
+      const edited = page.waitForResponse(
+        (r) => r.url().includes('/bulk/edit') && r.request().method() === 'POST',
+      )
+      await editor.getByRole('button', { name: 'Save' }).click()
+      expect((await edited).status()).toBe(200)
+
+      // Both rows moved into the new group...
+      await expect(
+        view.locator(`[data-quota-group="${fresh}"] [data-quota-row="${ids[0]}"]`),
+      ).toHaveCount(1)
+      await expect(
+        view.locator(`[data-quota-group="${fresh}"] [data-quota-row="${ids[1]}"]`),
+      ).toHaveCount(1)
+
+      // ...and the registry learned the name: a THIRD quota, never selected,
+      // is offered the chip in its own editor. This is the half that was
+      // broken — the rows carried a label nothing else knew existed.
+      await page.reload()
+      await expect(view.locator(`[data-quota-row="${ids[2]}"]`)).toBeVisible()
+      await view.locator(`[data-quota-row="${ids[2]}"]`).dblclick()
+      const third = page.getByRole('dialog')
+      await expect(third).toBeVisible()
+      await expect(third.getByRole('button', { name: fresh, exact: true })).toBeVisible()
+      await page.keyboard.press('Escape')
     } finally {
       await deleteTasks(page, ids)
     }

--- a/tests/e2e/track.spec.ts
+++ b/tests/e2e/track.spec.ts
@@ -395,34 +395,6 @@ test.describe('Quotas page', () => {
       await page.keyboard.press('Escape')
       await expect(page.getByRole('dialog')).toHaveCount(0)
 
-      // §5/A3: retiring a quota through the API — `is_tracked: false` — takes
-      // its period rule with it. A bare "FREQ=WEEKLY" left on an untracked task
-      // with no due date is evaluated as a schedule, and rrule.js places it on
-      // an arbitrary weekday, so the retired task would surface on a day nobody
-      // chose. There is no "stop tracking" button (see the editor test above),
-      // so the API is the whole of this path. Done on a quota of its own so the
-      // two above stay selectable for the bulk step below.
-      const retireId = await createTask(page, {
-        title: 'Probe quota to retire',
-        progress_target: 2,
-        rrule: 'FREQ=WEEKLY',
-      })
-      ids.push(retireId)
-      const retired = await page.request.patch(`/api/tasks/${retireId}`, {
-        data: { is_tracked: false, progress_target: 1 },
-      })
-      expect(retired.status()).toBe(200)
-      const retiredBody = (await retired.json()).data
-      expect(retiredBody.is_tracked).toBe(false)
-      expect(retiredBody.rrule).toBeNull()
-      expect(retiredBody.due_at).toBeNull()
-
-      // And a quota refuses a snooze outright (§5/A4).
-      const snoozed = await page.request.post(`/api/tasks/${ids[0]}/snooze`, {
-        data: { until: new Date(Date.now() + 3_600_000).toISOString() },
-      })
-      expect(snoozed.status()).toBe(400)
-
       // And the bar retires the set.
       await page.locator(`[data-quota-row="${ids[0]}"]`).click()
       await page.locator(`[data-quota-row="${ids[1]}"]`).click({ modifiers: ['Shift'] })
@@ -432,6 +404,49 @@ test.describe('Quotas page', () => {
         .click()
       await expect(page.locator(`[data-quota-row="${ids[0]}"]`)).toHaveCount(0)
       await expect(page.locator(`[data-quota-row="${ids[1]}"]`)).toHaveCount(0)
+
+      // §5/A3+A4, over the API — last, because both of these mutate the list
+      // this page is showing. Every write emits a sync event and QuotasView
+      // refreshes on it, so doing them mid-sequence re-rendered the rows out
+      // from under the clicks above. There is no "stop tracking" button (see
+      // the editor test), so the API is the whole of the retire path.
+      //
+      // Retiring takes the period rule with it: a bare "FREQ=WEEKLY" left on an
+      // untracked task with no due date is evaluated as a schedule, and rrule.js
+      // places it on an arbitrary weekday, so the task would surface on a day
+      // nobody chose.
+      const retireId = await createTask(page, {
+        title: 'Probe quota to retire',
+        progress_target: 2,
+        rrule: 'FREQ=WEEKLY',
+      })
+      ids.push(retireId)
+      await expect(page.locator(`[data-quota-row="${retireId}"]`)).toBeVisible()
+
+      const retired = await page.request.patch(`/api/tasks/${retireId}`, {
+        data: { is_tracked: false, progress_target: 1 },
+      })
+      expect(retired.status()).toBe(200)
+      const retiredBody = (await retired.json()).data
+      expect(retiredBody.is_tracked).toBe(false)
+      expect(retiredBody.rrule).toBeNull()
+      expect(retiredBody.due_at).toBeNull()
+      // It is no longer a quota, so it leaves this page — which is also how we
+      // know the refresh has landed, rather than by waiting a fixed time.
+      await expect(page.locator(`[data-quota-row="${retireId}"]`)).toHaveCount(0)
+
+      // Undo puts it back, flag and rule together. This is the path that used
+      // to throw inside undo's column allowlist and wedge the whole stack
+      // (`is_tracked` was not on it), so a green 200 here is the contract.
+      const undone = await page.request.post('/api/undo')
+      expect(undone.status()).toBe(200)
+      await expect(page.locator(`[data-quota-row="${retireId}"]`)).toBeVisible()
+
+      // And a quota refuses a snooze outright (§5/A4).
+      const snoozed = await page.request.post(`/api/tasks/${retireId}/snooze`, {
+        data: { until: new Date(Date.now() + 3_600_000).toISOString() },
+      })
+      expect(snoozed.status()).toBe(400)
     } finally {
       await deleteTasks(page, ids)
     }

--- a/tests/e2e/track.spec.ts
+++ b/tests/e2e/track.spec.ts
@@ -268,7 +268,14 @@ test.describe('Track', () => {
     }
   })
 
-  test('in the All list a quota is a plain row with its count as a chip', async ({
+  /**
+   * §5, amended 2026-09-08 (Trent): "a quota is not a task. It appears on the
+   * Quotas page and in the Track panel and nowhere else." It used to be a plain
+   * row in the All list wearing a "1 / 3 this week" chip, which put a thing
+   * with no due date, no snooze and no Done in among things that have all
+   * three. This pins both halves: gone from the list, still in the panel.
+   */
+  test('a quota is absent from the All list but still in the Track panel', async ({
     authenticatedPage: page,
   }) => {
     const id = await createTask(page, {
@@ -278,17 +285,31 @@ test.describe('Track', () => {
     })
     let before: View | null = null
     try {
-      // Log one through the API so the chip has a non-zero count to show.
       const logged = await page.request.post(`/api/tasks/${id}/progress`, { data: { delta: 1 } })
       expect(logged.ok()).toBeTruthy()
       await page.goto('/')
       await expect(page.getByRole('button', { name: 'All', exact: true })).toBeVisible()
       before = await pressedView(page)
       if (before !== 'All') await switchView(page, 'All')
-      const row = page.locator(`#task-row-${id}`)
-      await expect(row).toBeVisible()
-      await expect(row).toContainText('1 / 3 this week')
-      await expect(row.getByRole('button', { name: /Log one more/ })).toHaveCount(0)
+
+      // A plain task is here, so an empty assertion below cannot pass by the
+      // list simply not having rendered.
+      const plainId = await createTask(page, { title: 'Plain sibling task' })
+      try {
+        await page.reload()
+        if ((await pressedView(page)) !== 'All') await switchView(page, 'All')
+        await expect(page.locator(`#task-row-${plainId}`)).toBeVisible()
+        await expect(page.locator(`#task-row-${id}`)).toHaveCount(0)
+
+        // ...and the panel above the list still has it, with its count.
+        await openTrack(page)
+        const row = page.locator(`[data-track-row="${id}"]`)
+        await expect(row).toBeVisible()
+        await expect(row).toContainText('1')
+        await closeTrack(page)
+      } finally {
+        await deleteTasks(page, [plainId])
+      }
     } finally {
       if (before && before !== 'All') await switchView(page, before)
       await deleteTasks(page, [id])
@@ -365,6 +386,34 @@ test.describe('Quotas page', () => {
       await expect(page).toHaveURL(/\/quotas$/)
       await page.keyboard.press('Escape')
       await expect(page.getByRole('dialog')).toHaveCount(0)
+
+      // §5/A3: retiring a quota through the API — `is_tracked: false` — takes
+      // its period rule with it. A bare "FREQ=WEEKLY" left on an untracked task
+      // with no due date is evaluated as a schedule, and rrule.js places it on
+      // an arbitrary weekday, so the retired task would surface on a day nobody
+      // chose. There is no "stop tracking" button (see the editor test above),
+      // so the API is the whole of this path. Done on a quota of its own so the
+      // two above stay selectable for the bulk step below.
+      const retireId = await createTask(page, {
+        title: 'Probe quota to retire',
+        progress_target: 2,
+        rrule: 'FREQ=WEEKLY',
+      })
+      ids.push(retireId)
+      const retired = await page.request.patch(`/api/tasks/${retireId}`, {
+        data: { is_tracked: false, progress_target: 1 },
+      })
+      expect(retired.status()).toBe(200)
+      const retiredBody = (await retired.json()).data
+      expect(retiredBody.is_tracked).toBe(false)
+      expect(retiredBody.rrule).toBeNull()
+      expect(retiredBody.due_at).toBeNull()
+
+      // And a quota refuses a snooze outright (§5/A4).
+      const snoozed = await page.request.post(`/api/tasks/${ids[0]}/snooze`, {
+        data: { until: new Date(Date.now() + 3_600_000).toISOString() },
+      })
+      expect(snoozed.status()).toBe(400)
 
       // And the bar retires the set.
       await page.locator(`[data-quota-row="${ids[0]}"]`).click()

--- a/tests/e2e/track.spec.ts
+++ b/tests/e2e/track.spec.ts
@@ -351,6 +351,14 @@ test.describe('Quotas page', () => {
       const row = page.locator(`[data-quota-row="${ids[0]}"]`)
       await expect(row).toContainText('never met')
 
+      // Nobody labelled these, so they are in the Unlabelled group — a real
+      // group with a name, not a gap. And the row carries its own period now
+      // that the card it sits in is a label rather than a cadence.
+      const unlabelled = view.locator('[data-quota-group="unlabelled"]')
+      await expect(unlabelled).toContainText('Unlabelled')
+      await expect(unlabelled.locator(`[data-quota-row="${ids[0]}"]`)).toHaveCount(1)
+      await expect(row.locator('[data-quota-period]')).toHaveText('· week')
+
       // The house selection model: a plain click selects EXACTLY one and never
       // navigates. It does not accumulate — which is what it wrongly did when
       // this page first shipped.
@@ -463,6 +471,103 @@ test.describe('Quotas page', () => {
       await page.keyboard.press('Escape')
     } finally {
       await deleteTasks(page, [id])
+    }
+  })
+})
+
+test.describe('Quota labels', () => {
+  /**
+   * §5, Trent 2026-09-08: "I think we need to have one label for quotas… there's
+   * a bunch of stuff for the kids and there are other things." The label is the
+   * page's grouping, so the picker in the editor and the group a row sits in are
+   * one feature and are tested as one.
+   */
+  test('a quota is grouped by its one label, and the picker moves it', async ({
+    authenticatedPage: page,
+  }) => {
+    const ids: number[] = []
+    try {
+      // A quota that still carries TWO labels — six on Trent's corpus do, and
+      // the migration deliberately left them alone. It belongs to the FIRST.
+      // `create_label` is §7.2's opt-in: an unknown label is refused without it.
+      ids.push(
+        await createTask(page, {
+          title: 'Probe label two-label',
+          progress_target: 2,
+          rrule: 'FREQ=WEEKLY',
+          labels: ['health', 'kids'],
+          create_label: true,
+        }),
+      )
+      ids.push(
+        await createTask(page, {
+          title: 'Probe label house one',
+          progress_target: 1,
+          is_tracked: true,
+          rrule: 'FREQ=MONTHLY',
+          labels: ['house'],
+          create_label: true,
+        }),
+      )
+
+      await page.goto('/quotas')
+      const view = page.locator('[data-quotas-view]')
+      await expect(view).toBeVisible()
+
+      // Each lands under its own label, and the two-label one appears ONCE.
+      await expect(
+        view.locator(`[data-quota-group="health"] [data-quota-row="${ids[0]}"]`),
+      ).toHaveCount(1)
+      await expect(view.locator(`[data-quota-row="${ids[0]}"]`)).toHaveCount(1)
+      await expect(
+        view.locator(`[data-quota-group="house"] [data-quota-row="${ids[1]}"]`),
+      ).toHaveCount(1)
+      // The header counts quotas, never a sum of mixed targets.
+      await expect(view.locator('[data-quota-group="house"]')).toContainText('1 quota')
+
+      // Picking a different label moves the row to that group.
+      await view.locator(`[data-quota-row="${ids[1]}"]`).dblclick()
+      const editor = page.getByRole('dialog')
+      await expect(editor).toBeVisible()
+      await expect(editor.getByRole('button', { name: 'house', exact: true })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      )
+      const saved = page.waitForResponse(
+        (r) => r.url().includes(`/api/tasks/${ids[1]}`) && r.request().method() === 'PATCH',
+      )
+      await editor.getByRole('button', { name: 'health', exact: true }).click()
+      await editor.getByRole('button', { name: 'Save' }).click()
+      expect((await saved).status()).toBe(200)
+      await expect(
+        view.locator(`[data-quota-group="health"] [data-quota-row="${ids[1]}"]`),
+      ).toHaveCount(1)
+      await expect(view.locator('[data-quota-group="house"]')).toHaveCount(0)
+
+      // A label the registry has never heard of is typed in the same picker and
+      // registered by the save itself (`create_label`), so the new quota has a
+      // group of its own the moment it exists.
+      await view.getByRole('button', { name: 'New quota' }).click()
+      const form = page.getByRole('dialog')
+      await form.getByRole('textbox').first().fill('Probe label brand new')
+      await form.getByRole('button', { name: '+ New' }).click()
+      await form.getByRole('textbox', { name: 'New label' }).fill('probe-domain')
+      await form.getByRole('textbox', { name: 'New label' }).press('Enter')
+      await expect(form.getByRole('button', { name: 'probe-domain' })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      )
+      const created = page.waitForResponse(
+        (r) => r.url().endsWith('/api/tasks') && r.request().method() === 'POST',
+      )
+      await form.getByRole('button', { name: 'Create' }).click()
+      const newId = (await (await created).json()).data.id as number
+      ids.push(newId)
+      await expect(
+        view.locator(`[data-quota-group="probe-domain"] [data-quota-row="${newId}"]`),
+      ).toHaveCount(1)
+    } finally {
+      await deleteTasks(page, ids)
     }
   })
 })

--- a/tests/integration/quotas.test.ts
+++ b/tests/integration/quotas.test.ts
@@ -108,3 +108,91 @@ describe('Quotas surface API', () => {
     expect(after.quotas.map((q: { id: number }) => q.id)).not.toContain(id)
   })
 })
+
+/**
+ * A quota is not a task (§5, Trent 2026-09-08): it has no due date and cannot
+ * be snoozed, and retiring one takes its period rule with it. Pinned over HTTP
+ * because each of these is a route contract an external caller depends on —
+ * the automation API and the iOS app both PATCH tasks.
+ */
+describe('A quota over HTTP has no date and no snooze', () => {
+  beforeEach(async () => {
+    await resetTestData()
+  })
+
+  async function makeQuota(body: Record<string, unknown> = {}) {
+    const res = await apiFetch('/api/tasks', {
+      method: 'POST',
+      body: { title: 'Workouts', progress_target: 4, rrule: 'FREQ=WEEKLY', ...body },
+    })
+    return { status: res.status, body: (await res.json()).data }
+  }
+
+  test('POST /api/tasks never stamps a due date on a quota', async () => {
+    const { status, body } = await makeQuota()
+    expect(status).toBe(201)
+    expect(body.due_at).toBeNull()
+    expect(body.original_due_at).toBeNull()
+    expect(body.is_snoozed).toBe(false)
+  })
+
+  test('POST /api/tasks refuses a quota that is given a due date', async () => {
+    const { status } = await makeQuota({ due_at: new Date().toISOString() })
+    expect(status).toBe(400)
+  })
+
+  test('POST /api/tasks/:id/snooze on a quota is a 400', async () => {
+    const { body: quota } = await makeQuota()
+    const res = await apiFetch(`/api/tasks/${quota.id}/snooze`, {
+      method: 'POST',
+      body: { until: new Date(Date.now() + 3_600_000).toISOString() },
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test('PATCH converting a dated task into a quota clears the date', async () => {
+    const created = (
+      await (
+        await apiFetch('/api/tasks', {
+          method: 'POST',
+          body: { title: 'Becomes a quota', due_at: new Date().toISOString() },
+        })
+      ).json()
+    ).data
+    expect(created.due_at).not.toBeNull()
+
+    const res = await apiFetch(`/api/tasks/${created.id}`, {
+      method: 'PATCH',
+      body: { is_tracked: true, progress_target: 3, rrule: 'FREQ=WEEKLY' },
+    })
+    expect(res.status).toBe(200)
+    const patched = (await res.json()).data
+    expect(patched.due_at).toBeNull()
+    expect(patched.original_due_at).toBeNull()
+  })
+
+  test('POST /api/tasks/bulk/edit retiring a quota clears its period rule', async () => {
+    const { body: one } = await makeQuota({ title: 'Quota one' })
+    const { body: two } = await makeQuota({ title: 'Quota two' })
+
+    const res = await apiFetch('/api/tasks/bulk/edit', {
+      method: 'POST',
+      body: { ids: [one.id, two.id], changes: { is_tracked: false, progress_target: 1 } },
+    })
+    expect(res.status).toBe(200)
+
+    for (const id of [one.id, two.id]) {
+      const after = (await (await apiFetch(`/api/tasks/${id}`)).json()).data
+      expect(after.is_tracked).toBe(false)
+      expect(after.rrule).toBeNull()
+      expect(after.due_at).toBeNull()
+    }
+  })
+
+  test('GET /api/tasks/counts does not count quotas at all', async () => {
+    const before = (await (await apiFetch('/api/tasks/counts')).json()).data
+    await makeQuota({ title: 'Uncounted quota' })
+    const after = (await (await apiFetch('/api/tasks/counts')).json()).data
+    expect(after).toEqual(before)
+  })
+})

--- a/tests/integration/quotas.test.ts
+++ b/tests/integration/quotas.test.ts
@@ -196,3 +196,68 @@ describe('A quota over HTTP has no date and no snooze', () => {
     expect(after).toEqual(before)
   })
 })
+
+/**
+ * Review findings, 2026-09-08 — the two that are contracts an HTTP caller sees.
+ */
+describe('Quota review fixes over HTTP', () => {
+  beforeEach(async () => {
+    await resetTestData()
+  })
+
+  test('retiring a quota then undoing it is a 200, not a wedged stack', async () => {
+    const quota = (
+      await (
+        await apiFetch('/api/tasks', {
+          method: 'POST',
+          // The flag explicitly, so `is_tracked` reaches the undo snapshot's
+          // fieldsChanged — the field the allowlist used to throw on.
+          body: { title: 'Date night', is_tracked: true, rrule: 'FREQ=MONTHLY' },
+        })
+      ).json()
+    ).data
+
+    const retired = await apiFetch(`/api/tasks/${quota.id}`, {
+      method: 'PATCH',
+      body: { is_tracked: false },
+    })
+    expect(retired.status).toBe(200)
+
+    const undo = await apiFetch('/api/undo', { method: 'POST' })
+    expect(undo.status).toBe(200)
+
+    const after = (await (await apiFetch(`/api/tasks/${quota.id}`)).json()).data
+    expect(after.is_tracked).toBe(true)
+    expect(after.rrule).toBe('FREQ=MONTHLY')
+
+    // The stack is not wedged: a second Undo consumes the entry BELOW this
+    // one (the create) rather than hitting the same failed row again.
+    const second = await apiFetch('/api/undo', { method: 'POST' })
+    expect(second.status).toBe(200)
+  })
+
+  test("a quota's response carries its period anchor", async () => {
+    const quota = (
+      await (
+        await apiFetch('/api/tasks', {
+          method: 'POST',
+          body: { title: 'Workouts', progress_target: 4, rrule: 'FREQ=WEEKLY' },
+        })
+      ).json()
+    ).data
+
+    // Present and explicitly null — the iOS Track widget needs this field, not
+    // due_at, to know how far through its period a quota is.
+    expect(quota).toHaveProperty('progress_period_start')
+    expect(quota.progress_period_start).toBeNull()
+    expect(quota.due_at).toBeNull()
+
+    const fetched = (await (await apiFetch(`/api/tasks/${quota.id}`)).json()).data
+    expect(fetched).toHaveProperty('progress_period_start')
+
+    const listed = (await (await apiFetch('/api/quotas')).json()).data.quotas
+    expect(listed.find((q: { id: number }) => q.id === quota.id)).toHaveProperty(
+      'progress_period_start',
+    )
+  })
+})

--- a/tests/integration/quotas.test.ts
+++ b/tests/integration/quotas.test.ts
@@ -261,3 +261,75 @@ describe('Quota review fixes over HTTP', () => {
     )
   })
 })
+
+/**
+ * §7.2, second review finding 1: a label typed while editing SEVERAL quotas
+ * goes through `POST /api/tasks/bulk/edit`, which writes `labels` as raw SQL
+ * and never registered it. The rows carried the name and the registry had never
+ * heard of it, so the next editor did not offer the chip.
+ */
+describe('Bulk edit registers a new label', () => {
+  beforeEach(async () => {
+    await resetTestData()
+  })
+
+  async function makeQuota(title: string) {
+    return (
+      await (
+        await apiFetch('/api/tasks', {
+          method: 'POST',
+          body: { title, progress_target: 3, rrule: 'FREQ=WEEKLY' },
+        })
+      ).json()
+    ).data
+  }
+
+  const labelNames = async () =>
+    ((await (await apiFetch('/api/labels')).json()).data.labels as { name: string }[]).map(
+      (l) => l.name,
+    )
+
+  test('create_label on bulk/edit puts the name in the registry', async () => {
+    const one = await makeQuota('Quota one')
+    const two = await makeQuota('Quota two')
+    const fresh = `probe-${Date.now()}`
+    expect(await labelNames()).not.toContain(fresh)
+
+    const res = await apiFetch('/api/tasks/bulk/edit', {
+      method: 'POST',
+      body: { ids: [one.id, two.id], changes: { labels: [fresh], create_label: true } },
+    })
+    expect(res.status).toBe(200)
+
+    // Both rows carry it...
+    for (const id of [one.id, two.id]) {
+      const after = (await (await apiFetch(`/api/tasks/${id}`)).json()).data
+      expect(after.labels).toContain(fresh)
+    }
+    // ...and so does the registry, so the next editor offers the chip.
+    expect(await labelNames()).toContain(fresh)
+  })
+
+  test('labels_add registers too', async () => {
+    const one = await makeQuota('Quota three')
+    const fresh = `probe-add-${Date.now()}`
+
+    const res = await apiFetch('/api/tasks/bulk/edit', {
+      method: 'POST',
+      body: { ids: [one.id], changes: { labels_add: [fresh], create_label: true } },
+    })
+    expect(res.status).toBe(200)
+    expect(await labelNames()).toContain(fresh)
+  })
+
+  test('a caller that omits the flag is still accepted, as before', async () => {
+    // This endpoint has never validated labels. Registering on the flag must
+    // not turn every existing caller's unknown label into a rejection.
+    const one = await makeQuota('Quota four')
+    const res = await apiFetch('/api/tasks/bulk/edit', {
+      method: 'POST',
+      body: { ids: [one.id], changes: { labels: [`unregistered-${Date.now()}`] } },
+    })
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
Trent, 2026-09-08: **"a quota is not a task. It appears on the Quotas page and in the Track panel and nowhere else, it has no due date, and it cannot be snoozed."** Reminders (§6) already got exactly this carve-out; this is the same one for Track (§5), built on the same pattern rather than a new one.

## What changed

**A quota leaves every task list.** `visibleTasks` / `visibleSearchResults` in `DashboardClient` now drop tracked rows alongside reminders. Doing it at that one point takes them out of everything derived from the list — filter chip counts, "Showing N of M", header counts, keyboard order, select-all, the clipboard. `/api/tasks` still returns the whole corpus: the Track panel builds from that same fetch (now fed the unfiltered array through a new `quotaSource` prop) and so does the iOS widget. Server-side twins follow: `/api/tasks/counts`, the project badge SQL, and the AI task-summary candidate set. The `?task=<id>` deep link routes a quota to `/tasks/:id` (which already renders `QuotaDetail`) instead of the QuickActionPanel — that was the last path by which a quota could still reach a snooze grid.

**A quota has no due date.** `due_at` was vestigial — the period is carried by `progress_period_start` — but it was still a real date, so a quota read as overdue debt in the chips and project badges, and could be snoozed. `create.ts` no longer computes a first occurrence for a tracked row; `collectFieldChanges` refuses an incoming date and clears any date a row carries when it is (or becomes) a quota; `markDone` / `skipOccurrence` no longer advance one. That last one mattered more than it looks: asking rrule.js for the "next occurrence" of a bare `FREQ=WEEKLY` with no anchor and no previous date places it on an arbitrary weekday, and `computeMarkDone` has no try/catch, so a real quota could have 500'd `POST /api/tasks/:id/done`.

**Retiring a quota clears its rule.** `is_tracked: false` now also nulls the rrule, done in `collectFieldChanges` so `POST /api/tasks/bulk/edit` gets it for free. A bare period rule is legal only while tracked; left behind on an undated task it would be evaluated as a schedule.

**A quota cannot be snoozed** — 400 from `snoozeTask` and from the underlying PATCH. Bulk snooze already skipped them.

### Migration

Data-only, idempotent by construction, run on every start (there is no migrations table here, and no new column to hang a `hasColumn` guard on):

```sql
UPDATE tasks
   SET due_at = NULL, original_due_at = NULL
 WHERE (is_tracked = 1 OR progress_target > 1)
   AND (due_at IS NOT NULL OR original_due_at IS NOT NULL)
```

`original_due_at` goes too, or `is_snoozed` stays true in the API response for a row that cannot be snoozed.

### The `due_at` audit

Nothing server-side reads a quota's `due_at`. `period-rollover.ts` writes `due_at_was`/`due_at_next` on the completions row from the *period* bounds, not the task's date, and both columns are nullable. `mark-done.ts` and the progress route only write it.

The one real reader is **iOS `TrackWidget.elapsedFraction`**, which drew a pace tick from a `[due − periodLength, due]` window. That premise was already false: on the dev corpus 15 of 19 quotas held the same date in the past, while their real period anchor sat days later — so the window was entirely historical and every quota clamped to "maximally behind". The date was nulled rather than preserved. See "Not done" below.

## Testing

| Suite | Result |
|---|---|
| `type-check` / `lint` / `format:check` | pass — 0 errors. 99 warnings vs 98 on `main`: one new one, the 155-line `describe` in the new test file, matching four sibling test files that carry the same warning. No new warning classes. |
| Behavioral | **1037 passed**, 58 files (10 new in `tr-quota-no-date.test.ts`) |
| Integration | **255 passed**, 27 files (7 new in `quotas.test.ts`) |
| E2E | **60 passed** — no pre-existing failures observed |

Four existing tests created quotas *with* a `due_at` and were updated to the new rule (`tk-track` TK-007/TK-015, `sk-skip` SK-007, `tr-tracked-flag` TR-003); TK-007 and SK-007 now also assert the date stays null, and were switched to a bare `FREQ=WEEKLY` so they exercise what the corpus actually holds. The All-list E2E test was flipped from "a quota is a plain row with its count as a chip" to pinning both halves — absent from the list, still in the panel — and the Quotas-page test now pins the retire and snooze contracts.

## Verified on dev

https://tasks-dev.tk11.mcnitt.io — real corpus (129 open items: 42 tasks, 68 reminders, 19 quotas), screenshots at 1280×800 and 375×812.

- Migration ran clean: **19/19 quotas now have `due_at` and `original_due_at` null.**
- Projects view and All view: **0 quota rows** (42 rows each), on both viewports.
- Search: 0 quota rows.
- Filter chips exclude them — "No Due Date 7" and "Recurring 15" would be 26 and ~34 if quotas still counted.
- Track panel: still present on both views, **all 19** quotas.
- Quotas page: 19 rows, no date-like text anywhere.
- Quota detail: renders `QuotaDetail`, no date, no snooze, no Done.
- `/api/tasks/counts` returns `{total: 42, overdue: 19, today: 2}` — matches the DB exactly for non-quota, non-reminder tasks.
- No console errors or warnings; no HTTP ≥ 400. The only network noise is `net::ERR_ABORTED` on chunk and API requests torn down by the script's own rapid navigation.

## Not done / worth knowing

- **iOS `TrackWidget` pace tick is now blank.** With `due_at` null, `elapsedFraction` returns nil, so quotas get no tick and sort by id rather than by pace. Left unfixed on purpose: it needs a Swift change (derive the window from the device calendar, or expose `progress_period_start` in the API) and a device test, neither of which belongs in this PR. The tick it replaces was already meaningless — see the audit above.
- `TaskRow`'s tracked-chip rendering is now unreachable from the dashboard. Left in place rather than ripped out.
- The `?task=<id>` deep link now does `router.push` then `replaceState` back to back for a quota. Same shape as the existing `handleViewTask` path, but the comment two lines below documents an RSC-fetch failure mode on WebKit for exactly this flow. The failure here is benign — nothing opens and the param stays — but it is the one iOS-webview path not verified in a real webview.
- Archive, Trash and History can still contain a quota. Those are historical/recovery surfaces, deliberately untouched.
- `opentask-docs` may want a matching note on the `concepts/` snooze page and `openapi.json`; `docs/openapi.yaml` here is updated.

---

# Scope B — one label per quota, and the page groups by it

Trent, 2026-09-08: **"I think we need to have one label for quotas… there's a bunch of stuff for the kids and there are other things."** Nineteen quotas in one alphabetical wall is a list you scan, not a set you work with. Same branch, same PR, on top of the surfaces above.

## What changed

**The editor gets a single-select Label picker** (`QuotaDetail`, so it appears in the "New quota" dialog, the Quotas-page editor, the bulk editor, and the `/tasks/:id` quota page at once). Chips in the same shape as the period chips directly above them (`CadenceField`), coloured through `getLabelClasses` + `label_config` so a label looks the same here as in the filter bar. Options are the **domain** facet of the label registry (§7.2), fetched by a new `useDomainLabels` hook — the `operational` `ai-*` labels are machinery and are never offered. "None" is a real choice and sits first.

**A new name can be typed** ("+ New" swaps in an input; Enter or blur commits, Escape cancels) and is registered by the save itself through §7.2's **`create_label`** flag — the documented way to mint a label as part of a write, rather than a second mechanism. Storage is unchanged: the existing `labels` JSON column, holding one entry. No schema change, no migration.

**The picker is only sent when it was touched.** Six quotas on the corpus still carry TWO labels from before this rule, and the §5 migration deliberately left them alone; editing such a quota's target must not quietly drop its second label. Choosing a label does drop it — that is the point — and until then the **first** label is the one the page files it under, so a quota is always in exactly one group. Three states are kept apart in the editor (`string` / `null` "none" / `undefined` "the selection disagrees"), which is what lets "None" be chosen across a mixed multi-select.

**`groupByLabel` groups the Quotas page**, next to `groupByPeriod` in `src/lib/track.ts` and used by `QuotasView` only. Groups alphabetical (`sensitivity: 'base'`, matching `trackedItems`); **"Unlabelled" last**, because it is the leftovers rather than a name that happens to sort after "website"; the frozen alphabetical order kept inside each group, so a +1 never moves a row under a finger.

**The dashboard's Track panel still groups by period, on purpose** — it answers "what is left this week", where the period *is* the question. Here the period moves onto the row instead (`0 / 2 · week`), since a label group mixes cadences. It is rendered as a sibling of `data-quota-count`, which existing tests assert on exactly.

**The group header stopped summing progress**, for the same reason: 2/day + 3/week + 1/month is a number nobody can act on. It counts quotas instead — "8 quotas · 1 met" — through a new `quotaGroupSummary` (`met` is per-quota `trackState`). Selection, the floating bar, +1/−1, rapid-tap counting, "New quota", the empty states and the `data-quota-row` / `data-quotas-view` / `data-quota-selection-bar` hooks are untouched; the card gains `data-quota-group`.

## Testing

| Suite | Result |
|---|---|
| `type-check` / `lint` / `format:check` | pass — 0 errors, **99 warnings**, unchanged from the first half of this branch (no new ones) |
| Behavioral | **1046 passed**, 59 files (9 new in `tr-quota-labels.test.ts`) |
| Integration | **255 passed**, 27 files |
| E2E | **61 passed** — no failures, pre-existing or otherwise |

The Quotas-page E2E now pins the Unlabelled group and the row's period tag; a new `Quota labels` describe covers a two-label quota grouping under its first label, the picker moving a row from one group to another, and a typed label being registered by the save (`create_label`).

## Verified on dev

https://tasks-dev.tk11.mcnitt.io — real corpus, 19 quotas, screenshots at 1280×800 and 375×812.

All 19 in exactly one group each, six two-label rows under their **first** label:

| Group | n | Quotas |
|---|---|---|
| health | 6 | Cook daily vegetables · Daily Walks · Kids all blow up balloon\* · Kids Smoothie\* · Kids supplements\* · Weight Lift |
| house | 2 | Charge jump starter\* · Clean bedroom fans |
| job-hunt | 1 | Check for new certifications |
| kids | 2 | Clean car seat for Owen\* · Josie clean dishes\* |
| Unlabelled | 8 | Broccoli Avocado · Eggs · Grinding food · Kid's Iron Meal · Kids eat hard cereal · Owen (+Kids) Playground · Owen Swim · Peanut butter bites |

\* carries two labels; filed under the first.

- Picker offers all 13 domain labels + None + "+ New"; no `ai-*` label is offered.
- On a throwaway two-label quota: choosing `health` wrote `["health"]` and moved the row; a target-only edit on another left `["health","kids"]` intact.
- Dashboard Track panel unchanged — still DAY / WEEK / MONTH cards.
- No console errors or warnings; no HTTP ≥ 400.

## Not done / worth knowing

- **`POST /api/tasks/bulk/edit` ignores `create_label`** (it never validated labels — pre-existing, `validateLabelsExist` is only called by `createTask`/`updateTask`). So typing a *brand-new* name while editing several quotas at once still labels the tasks and groups them correctly, but does not add the name to the registry, and it will not be offered as a chip next time. Not fixed here: adding validation to the bulk path would 400 the existing `labels_add` callers that never send the flag.
- Group headers render plain on dev because Trent's `label_config` assigns no colours; a coloured label gets its registry colour automatically.
- `opentask-docs` has no page describing the Quotas surface yet; if one is added, the grouping belongs in it.

---

## Review fixes (2026-09-08)

A fresh-eyes pass over the quota carve-out found six paths it missed. **Each fix has a test that was verified red against the unfixed tree first** — I reverted the source changes and confirmed all six new tests fail, then restored them.

| # | Severity | What was wrong | Fix | Test |
|---|---|---|---|---|
| 1 | **HIGH** | Undo/redo of any `is_tracked` change threw and **wedged the undo stack**. `is_tracked` was missing from undo's column allowlist, which *throws* on an unknown field rather than skipping — and `undoEntry` runs inside the caller's transaction, so the throw rolled back the `undone = 1` write too. The entry stayed unconsumed and every later Undo landed on it again. Reached by retiring a quota and by the quota editor, which sends `is_tracked: true` whenever the target or period is touched. | `apply-fields.ts` — allowlist plus the 0/1 conversion branch `is_reminder` has (the snapshot holds the domain boolean; better-sqlite3 refuses to bind one). `execute-undo.ts` and `execute-redo.ts` share this function, so both are covered. | behavioral TR-020 (explicit flag → retire → undo → redo, asserting `rrule` returns too, since it rides the same `fieldsChanged`), TR-021 (editor path 0→1, two entries deep, proving the stack is not wedged), integration `retiring a quota then undoing it is a 200`, and the Quotas-page E2E |
| 2 | MEDIUM | Quick Take read the whole open corpus, so every quota — now undated — landed in the `undated` stat and was named to the model as a task. | `quick-take.ts` `buildFromDb` filters tracked **and** reminders, matching `buildTaskSummaries`. Exported for the test, the way `formatCompactTaskList` already is. | behavioral TR-025 — one plain task in, quota and reminder out of `text`, `tasks` and `stats.undated` |
| 3 | MEDIUM | `progress_period_start` was exposed nowhere, so with `due_at` gone the iOS widget's pace tick has nothing to read and its ordering degrades to lowest-id-first. | Added to `Task`, to both SELECTs + `TaskRow` + `rowToTask` in `create.ts`, and to `docs/openapi.yaml` ("period anchor; use it, not `due_at`, for pace"). **Swift deliberately untouched** — device-tested follow-up. | behavioral TR-026, integration `a quota's response carries its period anchor` (create, get, and `/api/quotas`) |
| 4 | LOW-MED | `{rrule: null, due_at: X}` — what the quick panel sends on "clear recurrence and pick a date" — fell into the snooze branch once the rrule guard was widened: `snooze_count` incremented, the snooze stat and `snooze` activity fired, and the row drew the snoozed indicator. | `collect-field-changes.ts` — snooze branch guarded with `!rruleChanged`. A recurrence change carrying a date is a re-schedule, not a deferral. | behavioral TR-022 |
| 5 | LOW-MED | Enrichment writes `due_at`, `rrule` and the derived anchors with raw SQL, bypassing the quota guards entirely. | `enrichment.ts` — gated on the re-read task's trackedness, covering both re-enrichment and a conversion mid-flight. Labels, priority, title and notes still apply. | behavioral `a date and a schedule from the model are dropped on a tracked task` in `ai-enrichment.test.ts` |
| 6 | LOW | A date-bearing bulk edit threw `QUOTA_DUE_DATE_MESSAGE` on a quota in the set, and one throw aborts the whole transaction — a sibling task's priority edit was lost with it. The existing snooze filter only covered a date sent *without* an rrule. | `bulk.ts` — date-bearing batches skip quotas and count them in `tasksSkipped`, before the snooze filter so the two never double-count. | behavioral TR-023 (`{due_at, rrule}`) and TR-024 (per-task date) |

### One thing beyond the six

Dev verification showed `PATCH {rrule: null, due_at: X}` still returning `is_snoozed: true` with `snooze_count: 0` — the other half of finding 4's stated symptom. `original_due_at` is the occurrence origin of the *old* schedule; changing the rrule to a new value already cleared it for that reason, but clearing it to null did not, because the block sat inside the "setting or changing recurrence" branch. A task created recurring has `original_due_at` set to its first occurrence, so the stale value survived and `is_snoozed` (and the row's snoozed indicator) is exactly `original_due_at !== null`. Hoisted so any rrule change clears it. TR-022 now asserts the origin is null rather than merely unchanged. Separate commit, `2818f47`.

Also fixed two stale comments that the first commit made false: `TrackPanel`'s own doc block still said quotas appear as rows in the All/Projects lists, and `filterForBulkSnooze` still described `due_at` as "vestigial, read by the iOS widget".

### Testing

| Suite | Result |
|---|---|
| type-check / format:check | pass |
| lint | 0 errors, **99 warnings** — unchanged. The second `describe` in `tr-quota-no-date.test.ts` was split so the file keeps one warning rather than two. |
| Behavioral | **1054 passed** / 59 files |
| Integration | **257 passed** / 27 files |
| E2E | **61 passed** — a clean full run |

One E2E failure on an earlier run, `dashboard.spec.ts:137` (filter section), is the known `filters_expanded` flake: passed 3/3 alone, not edited, and did not recur in the final full run.

I also found and fixed a **race I had introduced myself** in the E2E retire probe: it created and retired a quota through the API in the middle of a DOM interaction sequence on the Quotas page, and every write emits a sync event that re-renders the list under the clicks that follow. Moved after the DOM sequence and synchronised on the observable end state (the retired quota leaves the page) rather than on a timer. Track spec then ran 3/3 clean.

### Dev verification

https://tasks-dev.tk11.mcnitt.io, both viewports, screenshots `fix-*` in `.tmp/`. **Zero console errors/warnings, zero failed requests, no HTTP ≥ 400.**

- Retire → Undo on the Quotas page: retire 200 (`rrule: null`, `due_at: null`), row leaves the page; Undo 200, `is_tracked: true` and `rrule: FREQ=MONTHLY` restored, row returns; a second Undo and a Redo both 200 — the stack is not wedged.
- Clear recurrence + set a date on a task detail page: 200, `rrule: null`, date applied, `snooze_count: 0`, **`is_snoozed: false`**, description reads "Recurrence cleared, Due date set", no snoozed indicator on the row.
- Mixed bulk edit with a date: `{tasks_affected: 1, tasks_skipped: 1}` — the plain task's priority edit landed, the quota kept `due_at: null`.
- A new quota's response carries `progress_period_start`.

### Not fixed (confirmed pre-existing, flagged by the reviewer)

`POST /api/tasks/bulk/edit` never validates or registers labels, so a brand-new label typed while multi-editing quotas is not registered. And "Broccoli Avocado" reads "4 / 3" beside "never met" because `completion_count` counts rolled-over periods. Neither is touched here.

---

## Review fixes 2 (2026-09-08)

A second fresh-eyes pass over `b6ac28b..2818f47`. **Two of the five are regressions from the first round of fixes, not from the original change** — the hoist in `2818f47` was too wide. Every fix was verified red against the unfixed tree before being applied.

| # | What was wrong | Fix (file:line) | Pinned by |
|---|---|---|---|
| 1 | A new label typed while editing **several** quotas was written to the rows but never registered. `bulkEdit` hands `changes` to `collectFieldChanges`, which writes `labels` as raw SQL, and nothing called the registry — so "select two quotas → Label → + New → kids → Save" labelled both rows while the registry never learned `kids`, and the next editor did not offer the chip. | `bulk.ts:452-470` (`registerBulkEditLabels`), called at `:492`. Only on `create_label`, for both `labels` and `labels_add` — this endpoint has never validated labels, and validating unconditionally would start rejecting callers that work today. | integration ×3 in `quotas.test.ts` (registers via `labels`, via `labels_add`, and **a caller omitting the flag is still accepted**); E2E `a new label typed while editing several quotas reaches the registry`, which opens a **third** quota that was never selected and asserts the chip is offered |
| 2 | `quotaLabelOf` took `labels[0]` unfiltered, so a quota whose only label was operational got a group header reading "AI-FAILED" and that as its pressed chip. | `track.ts:136-146` — first **non-reserved** label. `QuotaDetail.tsx:386-397` no longer offers a reserved name as an option either. | behavioral `an operational label is never the label a quota is filed under` |
| 3 | `Kids` and `kids` are two registry rows (case-sensitive UNIQUE), drawing two groups whose headers both read "KIDS". | `track.ts:172-196` — `groupByLabel` keys case-insensitively, displays the first spelling seen (matching what `labels_add`/`labels_remove` already do). `QuotaDetail.tsx:399-411` — typing a name that matches an existing label in another case reuses that spelling. No schema change. | the existing test named `case does not split or reorder a group` passed two **different** labels, so it never tested case — rewritten to `Kids`/`kids`/`KIDS` → one group, with its real coverage kept in a new second test |
| 4 | **Mine.** `{reset_original_due_at: true, rrule: null}` pushed the reset and then `original_due_at = NULL` after it; SQLite takes the last clause, so the user's explicit reset lost. | `collect-field-changes.ts:320-345` — the reset always wins. This also fixes `{reset, rrule: <new rule>}`, which was overridden **before** this PR too. | behavioral TR-029 (both the null and the new-rule case) |
| 5 | **Mine.** `{rrule: null}` alone on a genuinely snoozed recurring task kept the deferred date and `snooze_count` but lost the origin — so the row stopped drawing its snoozed stripe and the quick panel's age anchor jumped back to `created_at`. | same block — narrowed to the pre-PR rule (a change to a new non-null rule) **plus** the case `2818f47` was actually for (a date arriving in the same request). | behavioral TR-027 (rule cleared alone → origin, count and date all survive) and TR-028 (a new rule still drops the origin — the pre-PR behaviour, guarded) |

`openapi.yaml` documented `task_ids` for bulk **done**, **edit** and **delete** while all three routes read `ids`. The review flagged edit; the other two were wrong the same way, so all three are corrected (`include_task_ids`/`exclude_task_ids` are genuinely named that and were left alone).

### Testing

| Suite | Result |
|---|---|
| type-check / format:check | pass |
| lint | 0 errors, **99 warnings** — unchanged. Extracting `registerBulkEditLabels` kept `bulkEdit` under the complexity cap, and the new describe block keeps `tr-quota-no-date.test.ts` at one warning. |
| Behavioral | **1059 passed** / 59 files |
| Integration | **260 passed** / 27 files |
| E2E | **62 passed**, twice in a row |

I also fixed a flake **of my own** that the last round did not fully close: the E2E retire probe created a quota through the API and then waited for the row to be *pushed* into an already-open page by the sync stream. That makes the test depend on delivery timing rather than on server state, and it failed once in a full run. It reloads now. Track spec 3/3 and the full suite 2/2 clean afterwards.

### Dev verification

https://tasks-dev.tk11.mcnitt.io, both viewports, screenshots `fix2-*` in `.tmp/`. **Zero console errors, zero failed requests, no HTTP ≥ 400.**

- Multi-quota new label: bulk edit 200, both rows in the new group, `GET /api/labels` now contains the name, and a **third quota never in the selection** is offered the chip in its own editor. No `ai-*` chip is offered anywhere in the picker.
- Snoozed recurring task losing its rule: `snooze_count` stays 2, `original_due_at` unchanged, `due_at` unchanged, `is_snoozed` still true — the deferral survives.
- `{reset_original_due_at: true, rrule: null}`: the origin becomes the current due date and `snooze_count` resets to 0 — the explicit reset wins.

One console error I chased rather than waved off: `Loading quotas failed: TypeError: Failed to fetch`. Four targeted probes could not reproduce it from any user action; it turned out my verification script did `page.reload()` while the post-save sync refresh was still in flight, aborting it — `QuotasView` deliberately swallows a failed background refresh but logs it first. Removing the redundant reload left the run clean. Not a page fault, and no code change was needed.

Probe data created on dev during verification has been cleaned up; the corpus is back to 42 tasks / 68 reminders / 19 quotas, zero quota due dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
