### PR TITLE
feat(track): the Track panel groups quotas by label, as one flowing stream

### DIFF
--- a/src/components/TrackPanel.tsx
+++ b/src/components/TrackPanel.tsx
@@ -4,14 +4,15 @@ import { useState } from 'react'
 import { Check, ChevronDown, Minus, Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { trackedItems } from '@/lib/slot-view'
-import { periodShort, groupByPeriod, trackSummary } from '@/lib/track'
+import { periodSuffix, trackStream, type TrackStreamItem } from '@/lib/track'
+import { LABEL_COLORS } from '@/lib/label-colors'
 import { useTrackProgress } from '@/hooks/useTrackProgress'
 import { useLongPress } from '@/hooks/useLongPress'
 import { useHorizontalSwipe } from '@/hooks/useHorizontalSwipe'
 import { TrackChipPopover } from '@/components/TrackChipPopover'
 import { GuardedLink } from '@/components/GuardedLink'
-import { useTrackPanelPreference } from '@/components/PreferencesProvider'
-import type { Task } from '@/types'
+import { useLabelConfig, useTrackPanelPreference } from '@/components/PreferencesProvider'
+import type { LabelColor, Task } from '@/types'
 
 /**
  * Track (REDESIGN-V03 §5): the quotas' home on the Tasks page.
@@ -22,24 +23,52 @@ import type { Task } from '@/types'
  * an instrument panel above the day, not rows inside it:
  *
  * - One line per quota, every line the same shape: title · bar · count · − · +1.
- *   The control cluster has fixed widths and sits flush right, so the eight
- *   lines align as one object. No circle, no stripes, no AI commentary, no
- *   recurrence glyph — none of that is what a counter is about.
- * - The panel is a plain group header ("TRACK") over one CARD per
- *   period — the Reminders slot card: word, count, a hairline that fills as
- *   the period goes. Two states, remembered as a user preference like the
- *   filter section. FOLDED (the default) each card holds its quotas as tight
- *   CHIPS with their full titles,
+ *   The control cluster has fixed widths and sits flush right, so the lines
+ *   align as one object. No circle, no AI commentary, no recurrence glyph —
+ *   none of that is what a counter is about.
+ * - The panel is a plain group header ("TRACK") over ONE card. Two states,
+ *   remembered as a user preference like the filter section. FOLDED (the
+ *   default) the card holds its quotas as tight CHIPS with their full titles,
  *   wrapping wherever the width runs out (Trent, 2026-09-05: eight open rows
  *   pushed the first task of the day below the fold on his phone; a folded
  *   one-liner hid the quotas; chips with truncated titles were rejected, so
  *   nothing here is ever cut). Tap a chip: +1. Hold it, or shift-click: −1.
  *   The chip's background fills as the count climbs and turns green at the
- *   target, so each chip is its own bar. OPEN, it is the full rows below.
- *   It always comes first.
- * - Order is by title and never changes on a tap — the widget's "order jumps
- *   under your finger" complaint applied verbatim here.
+ *   target, so each chip is its own bar. OPEN, it is the full rows.
+ * - Order is by label then title, and never changes on a tap — the widget's
+ *   "order jumps under your finger" complaint applied verbatim here.
  * - "Met" is a state, not an exit: green check, count keeps going (3/2).
+ *
+ * GROUPED BY LABEL, AS ONE STREAM (Trent, 2026-09-09, picking variation G of
+ * the `track-by-label` mockup, with D's stripe). It used to be one card per
+ * period — DAY / WEEK / MONTH, each with a summed progress bar. The label is
+ * the question a quota answers to ("there's a bunch of stuff for the kids and
+ * there are other things"), and the period is answered by two letters on the
+ * chip, so:
+ *
+ * - ONE card, holding ONE wrapping row. A cluster opens with its label in the
+ *   panel's own small uppercase run, which is a plain flex item: it attaches
+ *   after the previous cluster's last chip and wraps with everything else, so
+ *   it can never force a line break. That is what makes this the shortest of
+ *   the seven layouts drawn — 656px at 375px wide against the runner-up's 773.
+ * - NO summed bar. A bar across a group that mixes days, weeks and months is
+ *   "2 a day + 3 a week + 1 a month = 7", a number nobody can act on. The
+ *   Quotas page dropped it for the same reason when it moved to labels.
+ * - The period lives on the chip instead, as a muted suffix: 0/2·d, 0/3·wk.
+ * - A 3px stripe down the chip's left edge in the label's colour, and the same
+ *   colour as a dot on the title (variation D). The chip's radius drops from a
+ *   full pill to 10px so the stripe reads as a stripe rather than a crescent.
+ *   Colour comes from `label_config`, the same place every other label colour
+ *   in the app comes from; a label nobody has coloured, and the unlabelled
+ *   cluster, get a neutral one rather than a palette invented in code. Green is
+ *   reserved for "met" and is not spent on a label here.
+ *
+ * OPEN, the same clusters in the same order become headings over the full
+ * rows. Not drawn in the mockup — that was about the folded state, which is how
+ * the panel ships — but the alternative was for the grouping to vanish the
+ * moment the panel is expanded, and for the rows to be a flat list of 19 with
+ * no organising idea at all. The stripe stays on the chips only: a row already
+ * carries its own bar down that side of the panel.
  *
  * This panel and the Quotas page are the ONLY places a quota appears (Trent,
  * 2026-09-08: "a quota is not a task"). It used to be a plain row in the All
@@ -49,27 +78,20 @@ import type { Task } from '@/types'
  */
 export function TrackPanel({ tasks }: { tasks: Task[] }) {
   const { trackExpanded: open, setTrackExpanded: setOpen } = useTrackPanelPreference()
+  const { labelConfig } = useLabelConfig()
   // The quota whose detail sheet is showing. Held by id rather than by object
   // so a sync refresh replaces the rendered task underneath an open sheet.
   const [detailId, setDetailId] = useState<number | null>(null)
   const quotas = trackedItems(tasks)
+  const items = trackStream(quotas, labelConfig)
   if (quotas.length === 0) return null
-
-  // Quotas are grouped by period. With one period the header names it; with
-  // several, the header says nothing and each group sits under its own
-  // labelled hairline ("this week" / "this month"). Trent (2026-09-05): a
-  // period word on every chip was repetition, and still didn't tell a week
-  // from a month at a glance. The word appears once, on the divider.
-  // No total on the header: the cards carry their own counts, and a header
-  // count sat outside the cards' right edge (Trent, 2026-09-05).
-  const groups = groupByPeriod(quotas)
 
   return (
     <section aria-label="Track" data-track-panel className="mb-6">
       {/* A plain group header, built exactly like "Early morning" below —
           same padding, chevron size and negative margin — so the carets and
-          labels line up. The caret switches every card between chips and
-          the full rows. */}
+          labels line up. The caret switches the card between chips and the
+          full rows. */}
       <button
         type="button"
         onClick={() => setOpen(!open)}
@@ -91,95 +113,79 @@ export function TrackPanel({ tasks }: { tasks: Task[] }) {
         </span>
       </button>
 
-      {/* One card per period — the Reminders slot card: word top-left, count
-          top-right, a full-width hairline that fills as the period goes, then
-          the quotas (Trent chose this over nested boxes, 2026-09-05). */}
-      <div className="space-y-2.5">
-        {groups.map((g) => (
-          <PeriodCard
-            key={g.period ?? 'none'}
-            period={g.period}
-            tasks={g.tasks}
-            open={open}
-            detailId={detailId}
-            onOpenDetail={(t) => setDetailId(t.id)}
-            onCloseDetail={() => setDetailId(null)}
-          />
-        ))}
+      <div className="bg-muted/30 rounded-2xl p-2">
+        {open ? (
+          <ul aria-label="Quotas">
+            {items.map((item) =>
+              item.kind === 'title' ? (
+                <ClusterTitle
+                  key={`title-${item.label ?? 'unlabelled'}`}
+                  item={item}
+                  className="flex items-center gap-1.5 px-2 pt-3 pb-1 first:pt-1"
+                />
+              ) : (
+                <TrackRow key={item.task.id} task={item.task} />
+              ),
+            )}
+          </ul>
+        ) : (
+          // One wrapping row for the whole panel: titles and chips are peers in
+          // it, which is the entire trick — see the block comment above.
+          <ul className="flex flex-wrap items-center gap-1.5" aria-label="Quotas">
+            {items.map((item) =>
+              item.kind === 'title' ? (
+                <ClusterTitle
+                  key={`title-${item.label ?? 'unlabelled'}`}
+                  item={item}
+                  className="ml-2 flex items-center gap-1.5 whitespace-nowrap first:ml-0"
+                />
+              ) : (
+                <TrackChip
+                  key={item.task.id}
+                  task={item.task}
+                  color={item.color}
+                  detailOpen={detailId === item.task.id}
+                  onOpenDetail={(t) => setDetailId(t.id)}
+                  onCloseDetail={() => setDetailId(null)}
+                />
+              ),
+            )}
+          </ul>
+        )}
       </div>
     </section>
   )
 }
 
-function PeriodCard({
-  period,
-  tasks,
-  detailId,
-  onOpenDetail,
-  onCloseDetail,
-  open,
+/** A label with no colour configured, and the unlabelled cluster, get this. */
+const NEUTRAL = 'bg-muted-foreground/60'
+
+/** The flat colour a stripe or a swatch is painted in. */
+function colorClass(color: LabelColor | null): string {
+  return color ? LABEL_COLORS[color].dot : NEUTRAL
+}
+
+/**
+ * A cluster's heading. `whitespace-nowrap` on the whole run, so "job-hunt"
+ * never breaks at its hyphen when it lands at the end of a line.
+ */
+function ClusterTitle({
+  item,
+  className,
 }: {
-  period: string | null
-  tasks: Task[]
-  open: boolean
-  detailId: number | null
-  onOpenDetail: (task: Task) => void
-  onCloseDetail: () => void
+  item: Extract<TrackStreamItem, { kind: 'title' }>
+  className: string
 }) {
-  const word = period ? periodShort(period) : 'no period'
-  const s = trackSummary(tasks)
-  const met = s.total > 0 && s.done >= s.total
   return (
-    <div className="bg-muted/30 rounded-2xl px-2 pt-2 pb-2.5" data-track-period={word}>
-      <div className="flex items-center gap-2 px-1 pb-1.5">
-        <span className="text-muted-foreground text-[11px] font-semibold tracking-widest uppercase">
-          {word}
-        </span>
-        <span
-          className={cn(
-            'ml-auto text-xs whitespace-nowrap tabular-nums',
-            met ? 'text-green-700 dark:text-green-400' : 'text-muted-foreground',
-          )}
-        >
-          <span className="text-foreground font-medium">{s.done}</span> of {s.total}
-        </span>
-      </div>
-      <div
-        className="bg-muted mx-1 mb-2.5 h-1 overflow-hidden rounded-full"
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={s.total}
-        aria-valuenow={s.done}
-        aria-label={`${s.done} of ${s.total} ${period ?? ''}`.trim()}
-      >
-        <div
-          className={cn(
-            'h-full rounded-full transition-[width,background-color] duration-500 ease-out',
-            met ? 'bg-green-600' : 'bg-foreground/50',
-          )}
-          style={{ width: `${s.total > 0 ? (s.done / s.total) * 100 : 0}%` }}
-        />
-      </div>
-      {open ? (
-        <ul aria-label={word}>
-          {tasks.map((task) => (
-            <TrackRow key={task.id} task={task} />
-          ))}
-        </ul>
-      ) : (
-        <ul className="flex flex-wrap gap-1.5" aria-label={word}>
-          {tasks.map((task) => (
-            <TrackChip
-              key={task.id}
-              task={task}
-              detailOpen={detailId === task.id}
-              onOpenDetail={onOpenDetail}
-              onCloseDetail={onCloseDetail}
-            />
-          ))}
-        </ul>
-      )}
-    </div>
+    <li data-track-cluster={item.label ?? 'unlabelled'} className={className}>
+      <span
+        aria-hidden="true"
+        className={cn('size-2 shrink-0 rounded-full', colorClass(item.color))}
+      />
+      <span className="text-muted-foreground text-[11px] font-semibold tracking-widest uppercase">
+        {item.name}
+      </span>
+    </li>
   )
 }
 
@@ -200,11 +206,14 @@ function PeriodCard({
  */
 function TrackChip({
   task,
+  color,
   detailOpen,
   onOpenDetail,
   onCloseDetail,
 }: {
   task: Task
+  /** The cluster's colour; null paints the neutral stripe. */
+  color: LabelColor | null
   detailOpen: boolean
   onOpenDetail: (task: Task) => void
   onCloseDetail: () => void
@@ -212,6 +221,7 @@ function TrackChip({
   const { state, period, log } = useTrackProgress(task)
   const press = useLongPress({ onLongPress: () => onOpenDetail(task) })
   const swipe = useHorizontalSwipe({ onSwipeLeft: () => void log(-1) })
+  const suffix = period ? periodSuffix(period) : null
 
   return (
     <li className="max-w-full">
@@ -260,7 +270,10 @@ function TrackChip({
             // box cut the descenders off "Eggs" and "Grinding" (Trent, 2026-09-05).
             // touch-action pan-y, NOT touch-manipulation: the page must keep
             // scrolling vertically while the horizontal drag belongs to us.
-            'relative flex h-7 max-w-full touch-pan-y items-center gap-1.5 overflow-hidden rounded-full border px-2.5 text-[13px] leading-5 transition-colors select-none',
+            // rounded-[10px] rather than a full pill, and an extra 2px of left
+            // padding: at pill radius the 3px stripe is clipped into a crescent
+            // and stops reading as a stripe.
+            'relative flex h-7 max-w-full touch-pan-y items-center gap-1.5 overflow-hidden rounded-[10px] border pr-2.5 pl-3 text-[13px] leading-5 transition-colors select-none',
             'border-foreground/15 bg-background hover:border-foreground/40 active:scale-[0.98]',
             state.met && 'border-green-600/30',
           )}
@@ -273,6 +286,12 @@ function TrackChip({
             )}
             style={{ width: `${state.fraction * 100}%` }}
           />
+          {/* After the fill, not before it: a met chip's fill runs the whole
+              width, and underneath it the stripe would be tinted green. */}
+          <span
+            aria-hidden="true"
+            className={cn('absolute inset-y-0 left-0 w-[3px]', colorClass(color))}
+          />
           <span className="relative truncate">{task.title}</span>
           <span
             data-track-count
@@ -282,6 +301,15 @@ function TrackChip({
             )}
           >
             <span className="text-foreground font-medium">{state.current}</span>/{state.target}
+            {/* The period, two letters, always muted — even on a met chip,
+                where the count beside it goes green. It is which clock this
+                counts against, not part of the score. Hidden from a screen
+                reader, which gets the full period from the sr-only run. */}
+            {suffix && (
+              <span aria-hidden="true" className="text-muted-foreground">
+                ·{suffix}
+              </span>
+            )}
           </span>
           {period && <span className="sr-only"> {period}</span>}
         </button>

--- a/src/components/TrackPanel.tsx
+++ b/src/components/TrackPanel.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { Check, ChevronDown, Minus, Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { trackedItems } from '@/lib/slot-view'
-import { periodSuffix, trackStream, type TrackStreamItem } from '@/lib/track'
-import { LABEL_COLORS } from '@/lib/label-colors'
+import { periodSuffix, trackStream, trackStripeClass, type TrackStreamItem } from '@/lib/track'
 import { useTrackProgress } from '@/hooks/useTrackProgress'
 import { useLongPress } from '@/hooks/useLongPress'
 import { useHorizontalSwipe } from '@/hooks/useHorizontalSwipe'
@@ -30,9 +29,11 @@ import type { LabelColor, Task } from '@/types'
  *   remembered as a user preference like the filter section. FOLDED (the
  *   default) the card holds its quotas as tight CHIPS with their full titles,
  *   wrapping wherever the width runs out (Trent, 2026-09-05: eight open rows
- *   pushed the first task of the day below the fold on his phone; a folded
- *   one-liner hid the quotas; chips with truncated titles were rejected, so
- *   nothing here is ever cut). Tap a chip: +1. Hold it, or shift-click: −1.
+ *   pushed the first task of the day below the fold on his phone, and a folded
+ *   one-liner hid the quotas). A chip is as wide as its title needs, up to the
+ *   card; past that the title ellipsises, which on a phone the longest few do.
+ *   The count never truncates — it is the thing the chip is for. Open the panel,
+ *   or hold a chip, to read a title in full. Tap a chip: +1. Hold, or shift-click: −1.
  *   The chip's background fills as the count climbs and turns green at the
  *   target, so each chip is its own bar. OPEN, it is the full rows.
  * - Order is by label then title, and never changes on a tap — the widget's
@@ -47,10 +48,16 @@ import type { LabelColor, Task } from '@/types'
  * chip, so:
  *
  * - ONE card, holding ONE wrapping row. A cluster opens with its label in the
- *   panel's own small uppercase run, which is a plain flex item: it attaches
- *   after the previous cluster's last chip and wraps with everything else, so
- *   it can never force a line break. That is what makes this the shortest of
- *   the seven layouts drawn — 656px at 375px wide against the runner-up's 773.
+ *   panel's own small uppercase run — a plain flex item, so its chips flow
+ *   after it on the same line and wrap with everything else.
+ * - A TITLE ALWAYS STARTS ITS OWN ROW (Trent, 2026-09-09, on the dev build).
+ *   The mockup let a title attach after the previous cluster's last chip, which
+ *   is what made variation G the shortest of the seven drawn — but "house"
+ *   landing mid-row after a health chip read as confusing rather than compact.
+ *   A zero-height full-width `<li>` before each title after the first forces
+ *   the wrap; the title itself keeps no left margin, so it sits flush with the
+ *   card's left edge and the chips follow it across. The break is layout only,
+ *   which is why it lives here and not in `trackStream`.
  * - NO summed bar. A bar across a group that mixes days, weeks and months is
  *   "2 a day + 3 a week + 1 a month = 7", a number nobody can act on. The
  *   Quotas page dropped it for the same reason when it moved to labels.
@@ -61,7 +68,9 @@ import type { LabelColor, Task } from '@/types'
  *   Colour comes from `label_config`, the same place every other label colour
  *   in the app comes from; a label nobody has coloured, and the unlabelled
  *   cluster, get a neutral one rather than a palette invented in code. Green is
- *   reserved for "met" and is not spent on a label here.
+ *   reserved for "met", so `trackStripeClass` declines it: a label the user
+ *   coloured green gets a neutral stripe HERE, and keeps its green chips
+ *   everywhere else.
  *
  * OPEN, the same clusters in the same order become headings over the full
  * rows. Not drawn in the mockup — that was about the folded state, which is how
@@ -119,7 +128,7 @@ export function TrackPanel({ tasks }: { tasks: Task[] }) {
             {items.map((item) =>
               item.kind === 'title' ? (
                 <ClusterTitle
-                  key={`title-${item.label ?? 'unlabelled'}`}
+                  key={`title-${clusterKey(item.label)}`}
                   item={item}
                   className="flex items-center gap-1.5 px-2 pt-3 pb-1 first:pt-1"
                 />
@@ -132,13 +141,20 @@ export function TrackPanel({ tasks }: { tasks: Task[] }) {
           // One wrapping row for the whole panel: titles and chips are peers in
           // it, which is the entire trick — see the block comment above.
           <ul className="flex flex-wrap items-center gap-1.5" aria-label="Quotas">
-            {items.map((item) =>
+            {items.map((item, i) =>
               item.kind === 'title' ? (
-                <ClusterTitle
-                  key={`title-${item.label ?? 'unlabelled'}`}
-                  item={item}
-                  className="ml-2 flex items-center gap-1.5 whitespace-nowrap first:ml-0"
-                />
+                <Fragment key={`title-${clusterKey(item.label)}`}>
+                  {/* The wrap that puts this title at the start of a row. A
+                      full-basis, zero-height item fills whatever is left of the
+                      line above and takes no height of its own; the row gap on
+                      either side of it is the space between clusters. Not
+                      before the first title, which already starts row one. */}
+                  {i > 0 && <li aria-hidden="true" className="h-0 basis-full" />}
+                  <ClusterTitle
+                    item={item}
+                    className="flex max-w-full items-center gap-1.5 whitespace-nowrap"
+                  />
+                </Fragment>
               ) : (
                 <TrackChip
                   key={item.task.id}
@@ -157,17 +173,23 @@ export function TrackPanel({ tasks }: { tasks: Task[] }) {
   )
 }
 
-/** A label with no colour configured, and the unlabelled cluster, get this. */
-const NEUTRAL = 'bg-muted-foreground/60'
-
-/** The flat colour a stripe or a swatch is painted in. */
-function colorClass(color: LabelColor | null): string {
-  return color ? LABEL_COLORS[color].dot : NEUTRAL
+/**
+ * The grouping key a title carries in the DOM.
+ *
+ * The EMPTY STRING for the unlabelled cluster, not the word "unlabelled" or
+ * "other": a label with either of those names is legal, and would then share a
+ * key — and a selector — with the group of quotas that have no label at all.
+ * A label name is validated non-empty and trimmed (`validateLabelConfig`,
+ * `createLabel`), so "" is the one key no label can take.
+ */
+function clusterKey(label: string | null): string {
+  return label ?? ''
 }
 
 /**
- * A cluster's heading. `whitespace-nowrap` on the whole run, so "job-hunt"
- * never breaks at its hyphen when it lands at the end of a line.
+ * A cluster's heading. `whitespace-nowrap` so "job-hunt" never breaks at its
+ * hyphen, with `max-w-full truncate` behind it so a very long label ellipsises
+ * at the card's edge instead of pushing out of it.
  */
 function ClusterTitle({
   item,
@@ -177,12 +199,12 @@ function ClusterTitle({
   className: string
 }) {
   return (
-    <li data-track-cluster={item.label ?? 'unlabelled'} className={className}>
+    <li data-track-cluster={clusterKey(item.label)} className={className}>
       <span
         aria-hidden="true"
-        className={cn('size-2 shrink-0 rounded-full', colorClass(item.color))}
+        className={cn('size-2 shrink-0 rounded-full', trackStripeClass(item.color))}
       />
-      <span className="text-muted-foreground text-[11px] font-semibold tracking-widest uppercase">
+      <span className="text-muted-foreground min-w-0 truncate text-[11px] font-semibold tracking-widest uppercase">
         {item.name}
       </span>
     </li>
@@ -263,7 +285,14 @@ function TrackChip({
             if (press.didFire() || swipe.didSwipe()) return
             void log(e.shiftKey ? -1 : 1)
           }}
-          aria-label={`Log one more for "${task.title}"`}
+          // The count is IN the accessible name, not beside it. `aria-label`
+          // replaces a button's contents wholesale, so the count on screen and
+          // any sr-only run inside are never announced — and in the folded
+          // panel this chip is now the only progress there is, the period
+          // card's `progressbar` having gone with the cards.
+          aria-label={`Log one more for "${task.title}" — ${state.current} of ${state.target}${
+            period ? ` ${period}` : ''
+          }`}
           title="Tap: +1 · Swipe left, right-click or shift-click: −1 · Hold: details"
           className={cn(
             // leading-5, not leading-none: with the chip clipping its fill, a tight line
@@ -290,7 +319,7 @@ function TrackChip({
               width, and underneath it the stripe would be tinted green. */}
           <span
             aria-hidden="true"
-            className={cn('absolute inset-y-0 left-0 w-[3px]', colorClass(color))}
+            className={cn('absolute inset-y-0 left-0 w-[3px]', trackStripeClass(color))}
           />
           <span className="relative truncate">{task.title}</span>
           <span
@@ -303,15 +332,11 @@ function TrackChip({
             <span className="text-foreground font-medium">{state.current}</span>/{state.target}
             {/* The period, two letters, always muted — even on a met chip,
                 where the count beside it goes green. It is which clock this
-                counts against, not part of the score. Hidden from a screen
-                reader, which gets the full period from the sr-only run. */}
-            {suffix && (
-              <span aria-hidden="true" className="text-muted-foreground">
-                ·{suffix}
-              </span>
-            )}
+                counts against, not part of the score. Sighted-only by
+                construction: the button's `aria-label` spells the period out
+                in full. */}
+            {suffix && <span className="text-muted-foreground">·{suffix}</span>}
           </span>
-          {period && <span className="sr-only"> {period}</span>}
         </button>
       </TrackChipPopover>
     </li>
@@ -388,7 +413,14 @@ function TrackRow({ task }: { task: Task }) {
         <button
           type="button"
           onClick={() => void log(1)}
-          aria-label={`Log one more for "${task.title}"`}
+          // The count is IN the accessible name, not beside it. `aria-label`
+          // replaces a button's contents wholesale, so the count on screen and
+          // any sr-only run inside are never announced — and in the folded
+          // panel this chip is now the only progress there is, the period
+          // card's `progressbar` having gone with the cards.
+          aria-label={`Log one more for "${task.title}" — ${state.current} of ${state.target}${
+            period ? ` ${period}` : ''
+          }`}
           title="Log one more"
           className="text-foreground hover:bg-foreground/5 flex h-7 w-14 items-center justify-center gap-1 rounded-full border text-xs font-medium transition-colors"
         >

--- a/src/hooks/useTrackProgress.ts
+++ b/src/hooks/useTrackProgress.ts
@@ -11,20 +11,27 @@ import type { Task } from '@/types'
  *
  * While any request is in flight the caller shows this hook's own running
  * count: each tap adjusts it at once, and the requests go out ONE AT A TIME so
- * the server applies them in the order they were tapped. They used to fire
- * concurrently, which was wrong in a way nothing noticed for months: the server
- * clamps at zero (a correction may undo a mis-log, not manufacture history), so
- * a +1 and the −1 that takes it back, in flight together and applied in the
- * wrong order, clamp the −1 away and leave the count one too high — a state the
- * optimistic display hides until the next reload. Tap then Undo is the toast's
- * own advertised gesture, so that is the main path, not an edge case. Queuing
- * costs nothing visible: the count still moves on the tap. When the last
- * request settles, the server's answer is pinned until the task prop catches
- * up — keyed to the prop value it was pinned against, so a refetch (sync
- * stream, undo) that brings a *new* value replaces it and a stale one is
+ * the server applies them in the order they were tapped.
+ *
+ * They used to fire concurrently, which was wrong in a way nothing noticed for
+ * months. Progress never goes below zero — a correction can undo a mis-log, not
+ * manufacture history — so the server clamps, and from a count of 0 a +1 and
+ * the −1 that takes it back, in flight together and applied in the wrong order,
+ * clamp the −1 away and leave 1 behind. The optimistic display hides that until
+ * the next reload. Tap then Undo is the toast's own advertised gesture, so it
+ * is the main path, not an edge case.
+ *
+ * Queuing costs nothing on screen — the count still moves on the tap — but it
+ * does mean an un-sent tail exists: close the tab or hard-reload in the middle
+ * of a burst and the taps still in the queue are lost. A client navigation is
+ * fine, since the queue lives as long as the page.
+ *
+ * When the last request settles, the server's answer is pinned until the task
+ * prop catches up — keyed to the prop value it was pinned against, so a refetch
+ * (sync stream, undo) that brings a *new* value replaces it and a stale one is
  * ignored. That is what stops the count dipping to an older value for a beat
- * between a response and the refetch it triggers. A failed request reverts its own delta and says so. Progress never
- * goes below zero — a correction can undo a mis-log, not manufacture history.
+ * between a response and the refetch it triggers. A failed request reverts its
+ * own delta and says so.
  *
  * Every log shows a toast with Undo (Trent, 2026-09-05): a slip on a chip is
  * one tap to take back, no gesture to learn. Undo is simply the opposite
@@ -75,26 +82,31 @@ export function useTrackProgress(task: Task): {
         action: { label: 'Undo', onClick: () => void log(delta > 0 ? -1 : 1, { quiet: true }) },
       })
     }
-    // Never rejects, so one failed request cannot break the queue for the taps
-    // behind it.
-    const sent = queue.current.then(async () => {
-      try {
-        const res = await fetch(`/api/tasks/${task.id}/progress`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ delta }),
-        })
-        if (!res.ok) throw new Error('Failed to log progress')
-        const json = await res.json()
-        const settled = Number(json?.data?.progress_current)
-        if (Number.isFinite(settled)) setPinned({ base: serverRef.current, value: settled })
-      } catch {
-        setLocal((v) => Math.max(0, v - delta))
-        showToast({ message: `Could not log progress on "${task.title}"`, type: 'error' })
-      } finally {
-        setInFlight((n) => n - 1)
-      }
-    })
+    // `.catch()` before `.then()`, not only the try/catch inside: if anything
+    // below ever threw where the try does not reach — the catch block itself,
+    // the finally — a rejected tail would poison the chain permanently, and
+    // every later tap would move the optimistic count and never reach the
+    // server.
+    const sent = queue.current
+      .catch(() => {})
+      .then(async () => {
+        try {
+          const res = await fetch(`/api/tasks/${task.id}/progress`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ delta }),
+          })
+          if (!res.ok) throw new Error('Failed to log progress')
+          const json = await res.json()
+          const settled = Number(json?.data?.progress_current)
+          if (Number.isFinite(settled)) setPinned({ base: serverRef.current, value: settled })
+        } catch {
+          setLocal((v) => Math.max(0, v - delta))
+          showToast({ message: `Could not log progress on "${task.title}"`, type: 'error' })
+        } finally {
+          setInFlight((n) => n - 1)
+        }
+      })
     queue.current = sent
     await sent
   }

--- a/src/hooks/useTrackProgress.ts
+++ b/src/hooks/useTrackProgress.ts
@@ -19,11 +19,11 @@ import type { Task } from '@/types'
  * optimistic display hides until the next reload. Tap then Undo is the toast's
  * own advertised gesture, so that is the main path, not an edge case. Queuing
  * costs nothing visible: the count still moves on the tap. When the last
- * request settles, the server's answer is pinned until the task prop catches up — keyed to the prop value
- * it was pinned against, so a refetch (sync stream, undo) that brings a *new*
- * value replaces it and a stale one is ignored. That is what stops the count
- * dipping to an older value for a beat between a response and the refetch it
- * triggers. A failed request reverts its own delta and says so. Progress never
+ * request settles, the server's answer is pinned until the task prop catches
+ * up — keyed to the prop value it was pinned against, so a refetch (sync
+ * stream, undo) that brings a *new* value replaces it and a stale one is
+ * ignored. That is what stops the count dipping to an older value for a beat
+ * between a response and the refetch it triggers. A failed request reverts its own delta and says so. Progress never
  * goes below zero — a correction can undo a mis-log, not manufacture history.
  *
  * Every log shows a toast with Undo (Trent, 2026-09-05): a slip on a chip is

--- a/src/hooks/useTrackProgress.ts
+++ b/src/hooks/useTrackProgress.ts
@@ -10,9 +10,16 @@ import type { Task } from '@/types'
  * rapid taps.
  *
  * While any request is in flight the caller shows this hook's own running
- * count: each tap adjusts it at once, requests fire independently and the
- * server applies them in order. When the last request settles, the server's
- * answer is pinned until the task prop catches up — keyed to the prop value
+ * count: each tap adjusts it at once, and the requests go out ONE AT A TIME so
+ * the server applies them in the order they were tapped. They used to fire
+ * concurrently, which was wrong in a way nothing noticed for months: the server
+ * clamps at zero (a correction may undo a mis-log, not manufacture history), so
+ * a +1 and the −1 that takes it back, in flight together and applied in the
+ * wrong order, clamp the −1 away and leave the count one too high — a state the
+ * optimistic display hides until the next reload. Tap then Undo is the toast's
+ * own advertised gesture, so that is the main path, not an edge case. Queuing
+ * costs nothing visible: the count still moves on the tap. When the last
+ * request settles, the server's answer is pinned until the task prop catches up — keyed to the prop value
  * it was pinned against, so a refetch (sync stream, undo) that brings a *new*
  * value replaces it and a stale one is ignored. That is what stops the count
  * dipping to an older value for a beat between a response and the refetch it
@@ -49,6 +56,9 @@ export function useTrackProgress(task: Task): {
   // bounce 0 → 1 → 0 until the next refresh (Trent, 2026-09-05).
   const serverRef = useRef(serverCurrent)
   serverRef.current = serverCurrent
+  // The tail of this task's request queue. Assigned synchronously inside `log`,
+  // before any await, so two taps in the same tick still queue in order.
+  const queue = useRef<Promise<void>>(Promise.resolve())
 
   const log = async (delta: 1 | -1, options?: { quiet?: boolean }) => {
     const shown = displayedRef.current
@@ -65,22 +75,28 @@ export function useTrackProgress(task: Task): {
         action: { label: 'Undo', onClick: () => void log(delta > 0 ? -1 : 1, { quiet: true }) },
       })
     }
-    try {
-      const res = await fetch(`/api/tasks/${task.id}/progress`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ delta }),
-      })
-      if (!res.ok) throw new Error('Failed to log progress')
-      const json = await res.json()
-      const settled = Number(json?.data?.progress_current)
-      if (Number.isFinite(settled)) setPinned({ base: serverRef.current, value: settled })
-    } catch {
-      setLocal((v) => Math.max(0, v - delta))
-      showToast({ message: `Could not log progress on "${task.title}"`, type: 'error' })
-    } finally {
-      setInFlight((n) => n - 1)
-    }
+    // Never rejects, so one failed request cannot break the queue for the taps
+    // behind it.
+    const sent = queue.current.then(async () => {
+      try {
+        const res = await fetch(`/api/tasks/${task.id}/progress`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ delta }),
+        })
+        if (!res.ok) throw new Error('Failed to log progress')
+        const json = await res.json()
+        const settled = Number(json?.data?.progress_current)
+        if (Number.isFinite(settled)) setPinned({ base: serverRef.current, value: settled })
+      } catch {
+        setLocal((v) => Math.max(0, v - delta))
+        showToast({ message: `Could not log progress on "${task.title}"`, type: 'error' })
+      } finally {
+        setInFlight((n) => n - 1)
+      }
+    })
+    queue.current = sent
+    await sent
   }
 
   return { state, period, log }

--- a/src/lib/label-colors.ts
+++ b/src/lib/label-colors.ts
@@ -71,14 +71,29 @@ const AI_LABEL_COLORS: Record<string, string> = {
 }
 
 /**
+ * The colour a label is configured with, or null when it has none.
+ *
+ * The colour NAME, not the classes: a caller that paints ONE flat colour — the
+ * Track panel's 3px stripe and its cluster swatch — wants `LABEL_COLORS[c].dot`,
+ * and would otherwise have to pick the background back out of the pair of
+ * classes `getLabelClasses` returns. The `ai-*` colours are deliberately absent
+ * here: those are hard-wired class pairs for a label that is machinery, not a
+ * colour the user chose, and nothing files anything under them.
+ */
+export function getLabelColor(label: string, config: LabelConfig[]): LabelColor | null {
+  const lowerLabel = label.toLowerCase()
+  return config.find((c) => c.name.toLowerCase() === lowerLabel)?.color ?? null
+}
+
+/**
  * Returns combined bg + text classes for a label if it matches a predefined label,
  * or null for ad-hoc labels.
  */
 export function getLabelClasses(label: string, config: LabelConfig[]): string | null {
   const lowerLabel = label.toLowerCase()
   if (AI_LABEL_COLORS[lowerLabel]) return AI_LABEL_COLORS[lowerLabel]
-  const match = config.find((c) => c.name.toLowerCase() === lowerLabel)
-  if (!match) return null
-  const colorDef = LABEL_COLORS[match.color]
+  const color = getLabelColor(label, config)
+  if (!color) return null
+  const colorDef = LABEL_COLORS[color]
   return `${colorDef.bg} ${colorDef.text}`
 }

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -5,7 +5,7 @@
  * row component runs in the browser and only needs to read a task's tracked
  * state and name its period. Kept here so a client bundle never pulls core.
  */
-import { getLabelColor } from '@/lib/label-colors'
+import { getLabelColor, LABEL_COLORS } from '@/lib/label-colors'
 import { isReservedLabel } from '@/lib/label-vocabulary'
 import type { LabelColor, LabelConfig, Task } from '@/types'
 
@@ -73,7 +73,7 @@ export function periodLabel(rrule: string | null | undefined): string | null {
   return freq ? (QUOTA_PERIODS.find((p) => p.freq === freq)?.label ?? null) : null
 }
 
-/** "this week" → "week", for a card's heading. */
+/** "this week" → "week", for the period tag on a Quotas page row. */
 export function periodShort(label: string): string {
   return QUOTA_PERIODS.find((p) => p.label === label)?.short ?? label
 }
@@ -98,7 +98,15 @@ export interface TrackSummary {
   total: number
 }
 
-/** The folded panel's one number: "2 of 23 this week". */
+/**
+ * Capped progress over summed targets: "2 of 23 this week".
+ *
+ * CURRENTLY UNCALLED in src/. It was the Track panel's period-card number until
+ * the panel moved to label clusters (2026-09-09), and a label group mixes
+ * periods, so adding its targets up would be meaningless — see
+ * `quotaGroupSummary`, which counts quotas instead. Kept, with its tests, for a
+ * future surface that groups by period again, where the sum is honest.
+ */
 export function trackSummary(
   tasks: Pick<Task, 'progress_target' | 'progress_current'>[],
 ): TrackSummary {
@@ -114,6 +122,9 @@ export function trackSummary(
 
 /**
  * Quotas by period, day-to-year, each group keeping the order it was given.
+ *
+ * CURRENTLY UNCALLED in src/, for the same reason as `trackSummary`: the Track
+ * panel groups by label now. Kept, with its tests, for a future period view.
  *
  * Ordered by QUOTA_PERIODS rather than a hand-written list, so a period added
  * to the table cannot be silently dropped from the grouping — and the
@@ -215,8 +226,16 @@ export function groupByLabel(
   }))
 }
 
-/** The name the no-label cluster goes by — a group of things, not a gap. */
-const UNLABELLED = 'Unlabelled'
+/**
+ * The name the no-label cluster goes by — a group of things, not a gap.
+ *
+ * "Other", not the Quotas page's "Unlabelled" (Trent, 2026-09-09). The panel's
+ * titles sit inline among the chips at a small size, where "Unlabelled" reads
+ * as a state of the quotas under it rather than as the name of a group; the
+ * page has a card header with room to say the longer word. The grouping key is
+ * still `unlabelled` in both places — it is the same null label.
+ */
+const NO_LABEL_NAME = 'Other'
 
 /** A cluster's heading: the label's name, and the colour it is drawn in. */
 export interface TrackStreamTitle {
@@ -250,19 +269,40 @@ export type TrackStreamItem = TrackStreamTitle | TrackStreamChip
  * height of the seven variations drawn. Nesting the clusters in their own
  * elements would put a wrap boundary between them and undo that.
  *
- * Order is `groupByLabel`'s — alphabetical, case-insensitive, "Unlabelled"
- * last — and within a cluster the frozen alphabetical order `trackedItems`
+ * Order is `groupByLabel`'s — alphabetical, case-insensitive, the unlabelled
+ * cluster last — and within a cluster the frozen alphabetical order `trackedItems`
  * gave, so logging on one quota never reorders the others under a finger.
  *
  * The colour is resolved once per cluster and copied onto its chips: the chip
  * needs it for its stripe and the title for its swatch, and they must not be
  * able to disagree.
  */
+/**
+ * Neutral: no colour configured, the unlabelled cluster, or a colour the panel
+ * cannot spend.
+ */
+export const TRACK_NEUTRAL_CLASS = 'bg-muted-foreground/60'
+
+/**
+ * The flat colour a chip's stripe and a cluster's swatch are painted in.
+ *
+ * GREEN IS NOT AVAILABLE HERE. Green already means "met" on these chips — the
+ * fill and the border both turn green at the target — so a label configured
+ * green would put a permanent met-coloured mark on quotas that are not met.
+ * Settings offers green like any other colour and should keep doing so; the
+ * label's chips elsewhere in the app are unaffected. Only this stripe declines
+ * it, and falls back to neutral.
+ */
+export function trackStripeClass(color: LabelColor | null): string {
+  if (color === null || color === 'green') return TRACK_NEUTRAL_CLASS
+  return LABEL_COLORS[color].dot
+}
+
 export function trackStream(quotas: Task[], labelConfig: LabelConfig[]): TrackStreamItem[] {
   const out: TrackStreamItem[] = []
   for (const group of groupByLabel(quotas)) {
     const color = group.label ? getLabelColor(group.label, labelConfig) : null
-    out.push({ kind: 'title', name: group.label ?? UNLABELLED, label: group.label, color })
+    out.push({ kind: 'title', name: group.label ?? NO_LABEL_NAME, label: group.label, color })
     for (const task of group.tasks) out.push({ kind: 'chip', task, color })
   }
   return out

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -5,8 +5,9 @@
  * row component runs in the browser and only needs to read a task's tracked
  * state and name its period. Kept here so a client bundle never pulls core.
  */
+import { getLabelColor } from '@/lib/label-colors'
 import { isReservedLabel } from '@/lib/label-vocabulary'
-import type { Task } from '@/types'
+import type { LabelColor, LabelConfig, Task } from '@/types'
 
 /**
  * A tracked task is a quota: something to do N times per period. N > 1 implies
@@ -47,10 +48,10 @@ export function trackState(
  * Anything that needs to know about periods reads this.
  */
 export const QUOTA_PERIODS = [
-  { freq: 'DAILY', label: 'today', short: 'day', editor: 'Every day' },
-  { freq: 'WEEKLY', label: 'this week', short: 'week', editor: 'Every week' },
-  { freq: 'MONTHLY', label: 'this month', short: 'month', editor: 'Every month' },
-  { freq: 'YEARLY', label: 'this year', short: 'year', editor: 'Every year' },
+  { freq: 'DAILY', label: 'today', short: 'day', suffix: 'd', editor: 'Every day' },
+  { freq: 'WEEKLY', label: 'this week', short: 'week', suffix: 'wk', editor: 'Every week' },
+  { freq: 'MONTHLY', label: 'this month', short: 'month', suffix: 'mo', editor: 'Every month' },
+  { freq: 'YEARLY', label: 'this year', short: 'year', suffix: 'yr', editor: 'Every year' },
 ] as const
 
 export type QuotaFreq = (typeof QUOTA_PERIODS)[number]['freq']
@@ -75,6 +76,19 @@ export function periodLabel(rrule: string | null | undefined): string | null {
 /** "this week" → "week", for a card's heading. */
 export function periodShort(label: string): string {
   return QUOTA_PERIODS.find((p) => p.label === label)?.short ?? label
+}
+
+/**
+ * "this week" → "wk", for the two-letter suffix a chip's count carries.
+ *
+ * Null rather than the label when the period is not one this app knows: the
+ * suffix is decoration on a count, and printing "0/3·this week" inside a chip
+ * would be worse than printing nothing. In the table with everything else about
+ * a period, because that table exists precisely because this mapping used to be
+ * written out in five places and two of them had drifted.
+ */
+export function periodSuffix(label: string): string | null {
+  return QUOTA_PERIODS.find((p) => p.label === label)?.suffix ?? null
 }
 
 export interface TrackSummary {
@@ -165,9 +179,11 @@ export function quotaLabelOf(quota: Pick<Task, 'labels'>): string | null {
  * order), because logging on one quota must never reorder the others under the
  * user's finger.
  *
- * The dashboard's Track panel deliberately still groups by PERIOD: it is an
- * instrument for "what is left this week", where the period is the question.
- * Here the period is on each row instead, since a label group mixes them.
+ * The dashboard's Track panel groups by this too (see `trackStream`), so a
+ * quota sits under the same name in both places. Neither surface can carry a
+ * summed progress bar as a result — a label group mixes days, weeks and months
+ * by construction — so the period travels with each quota instead: a suffix on
+ * the panel's chips, a `· week` on the page's rows.
  */
 export function groupByLabel(
   quotas: Pick<Task, 'labels'>[],
@@ -197,4 +213,57 @@ export function groupByLabel(
     label: key === null ? null : (display.get(key) ?? key),
     tasks: by.get(key)!,
   }))
+}
+
+/** The name the no-label cluster goes by — a group of things, not a gap. */
+const UNLABELLED = 'Unlabelled'
+
+/** A cluster's heading: the label's name, and the colour it is drawn in. */
+export interface TrackStreamTitle {
+  kind: 'title'
+  /** As shown — the label, or "Unlabelled". */
+  name: string
+  /** The label itself, null for the unlabelled cluster. The grouping key. */
+  label: string | null
+  /** From `label_config`; null when the label has no colour configured. */
+  color: LabelColor | null
+}
+
+/** One quota, carrying the colour of the cluster it belongs to. */
+export interface TrackStreamChip {
+  kind: 'chip'
+  task: Task
+  color: LabelColor | null
+}
+
+export type TrackStreamItem = TrackStreamTitle | TrackStreamChip
+
+/**
+ * The Track panel's quotas as ONE flat stream: a title, its quotas, the next
+ * title, its quotas (Trent, 2026-09-09, choosing variation G from the mockup).
+ *
+ * Flat, rather than the nested `{ label, tasks }[]` `groupByLabel` returns,
+ * because the panel renders it as a single wrapping flex row in which a title
+ * is just another item. That is the whole point of the layout: the heading
+ * attaches after the previous cluster's last chip and wraps with everything
+ * else, so it can never force a line break and the panel costs the least
+ * height of the seven variations drawn. Nesting the clusters in their own
+ * elements would put a wrap boundary between them and undo that.
+ *
+ * Order is `groupByLabel`'s — alphabetical, case-insensitive, "Unlabelled"
+ * last — and within a cluster the frozen alphabetical order `trackedItems`
+ * gave, so logging on one quota never reorders the others under a finger.
+ *
+ * The colour is resolved once per cluster and copied onto its chips: the chip
+ * needs it for its stripe and the title for its swatch, and they must not be
+ * able to disagree.
+ */
+export function trackStream(quotas: Task[], labelConfig: LabelConfig[]): TrackStreamItem[] {
+  const out: TrackStreamItem[] = []
+  for (const group of groupByLabel(quotas)) {
+    const color = group.label ? getLabelColor(group.label, labelConfig) : null
+    out.push({ kind: 'title', name: group.label ?? UNLABELLED, label: group.label, color })
+    for (const task of group.tasks) out.push({ kind: 'chip', task, color })
+  }
+  return out
 }

--- a/tests/behavioral/tr-track-stream.test.ts
+++ b/tests/behavioral/tr-track-stream.test.ts
@@ -1,0 +1,147 @@
+/**
+ * The Track panel's stream (§5, Trent 2026-09-09 — variation G of the
+ * `track-by-label` mockup, with D's stripe).
+ *
+ * The panel draws its quotas as ONE wrapping row in which a cluster's heading
+ * is a peer of the chips rather than a container around them, so the thing
+ * under test is a FLAT ordered list: title, its quotas, the next title, its
+ * quotas. Everything the panel needs to paint a stripe travels in that list,
+ * which is why the colour is resolved here and not in the component.
+ *
+ * Pure functions over plain objects — no database, no clock, so nothing here
+ * depends on when it runs.
+ */
+import { describe, test, expect } from 'vitest'
+import { trackStream, periodSuffix, type TrackStreamItem } from '@/lib/track'
+import type { LabelConfig, Task } from '@/types'
+
+const quota = (title: string, labels: string[], rrule = 'FREQ=WEEKLY'): Task =>
+  ({ title, labels, rrule, progress_current: 0, progress_target: 3 }) as Task
+
+/** The corpus as `trackedItems` hands it over: alphabetical, case-insensitive. */
+const CORPUS = [
+  quota('Beef For Kids', []),
+  quota('Check for new certifications', ['job-hunt']),
+  quota('Clean bedroom fans', ['house'], 'FREQ=MONTHLY'),
+  quota('Cook daily vegetables', ['health']),
+  quota('Daily Walks', ['health'], 'FREQ=DAILY'),
+  quota('Eggs', []),
+  quota('Josie clean dishes (chore)', ['kids']),
+  quota('Kids Smoothie', ['health', 'kids']),
+]
+
+const CONFIG: LabelConfig[] = [
+  { name: 'health', color: 'blue' },
+  { name: 'house', color: 'orange' },
+  { name: 'kids', color: 'purple' },
+]
+
+const titles = (items: TrackStreamItem[]) =>
+  items.filter((i) => i.kind === 'title').map((i) => i.name)
+
+/** Every item as "TITLE" or "· chip title", so order reads as one sequence. */
+const shape = (items: TrackStreamItem[]) =>
+  items.map((i) => (i.kind === 'title' ? i.name : `· ${i.task.title}`))
+
+describe('the Track panel streams its quotas by label', () => {
+  test('a title opens each cluster, alphabetically, unlabelled last', () => {
+    const items = trackStream(CORPUS, CONFIG)
+    expect(titles(items)).toEqual(['health', 'house', 'job-hunt', 'kids', 'Unlabelled'])
+    // Not "no label": the leftovers are a named group, and they sort last
+    // however the names happen to fall.
+    expect(items[items.length - 1]).toMatchObject({ kind: 'chip' })
+  })
+
+  test('every chip follows its own title, and each quota appears exactly once', () => {
+    const items = trackStream(CORPUS, CONFIG)
+    expect(shape(items)).toEqual([
+      'health',
+      '· Cook daily vegetables',
+      '· Daily Walks',
+      // Two labels, filed under the FIRST — it is not in the kids cluster too.
+      '· Kids Smoothie',
+      'house',
+      '· Clean bedroom fans',
+      'job-hunt',
+      '· Check for new certifications',
+      'kids',
+      '· Josie clean dishes (chore)',
+      'Unlabelled',
+      '· Beef For Kids',
+      '· Eggs',
+    ])
+    const chips = items.filter((i) => i.kind === 'chip')
+    expect(chips).toHaveLength(CORPUS.length)
+    expect(new Set(chips.map((c) => c.task.title)).size).toBe(CORPUS.length)
+  })
+
+  test('the first item is always a title, so nothing is orphaned', () => {
+    expect(trackStream([quota('Eggs', [])], [])[0]).toMatchObject({
+      kind: 'title',
+      name: 'Unlabelled',
+      label: null,
+    })
+  })
+
+  test('a cluster keeps the order it was given — a tap never reshuffles it', () => {
+    // `trackedItems` froze this order; grouping must not re-sort within it.
+    const given = [quota('Weight Lift', ['health']), quota('Cook', ['health'])]
+    expect(shape(trackStream(given, CONFIG))).toEqual(['health', '· Weight Lift', '· Cook'])
+  })
+
+  test('an empty corpus is an empty stream, not a lone title', () => {
+    expect(trackStream([], CONFIG)).toEqual([])
+  })
+})
+
+describe('the colour a cluster is drawn in', () => {
+  test('comes from label_config, and is copied onto its chips', () => {
+    const items = trackStream([quota('Daily Walks', ['health'])], CONFIG)
+    expect(items).toEqual([
+      { kind: 'title', name: 'health', label: 'health', color: 'blue' },
+      { kind: 'chip', task: expect.objectContaining({ title: 'Daily Walks' }), color: 'blue' },
+    ])
+  })
+
+  test('is null when the label has no colour configured — a neutral stripe', () => {
+    // Trent's labels carry no colours today, so this is the shipping case, not
+    // an edge one: the panel must read as itself with an empty config.
+    const items = trackStream(CORPUS, [])
+    expect(items.every((i) => i.color === null)).toBe(true)
+  })
+
+  test('is null for the unlabelled cluster even when a label is named ""', () => {
+    const items = trackStream([quota('Eggs', [])], [{ name: 'Unlabelled', color: 'red' }])
+    // "Unlabelled" is this panel's word for the gap, not a label anybody can
+    // colour by registering that name.
+    expect(items.map((i) => i.color)).toEqual([null, null])
+  })
+
+  test('matches a label whatever case it was configured in', () => {
+    const items = trackStream([quota('Josie dishes', ['kids'])], [{ name: 'Kids', color: 'pink' }])
+    expect(items.map((i) => i.color)).toEqual(['pink', 'pink'])
+  })
+
+  test('a reserved ai-* label is not a colour, because it is not a filing', () => {
+    // `quotaLabelOf` skips them, so such a quota is unlabelled and neutral —
+    // it must not pick up ai-failed's hard-wired red.
+    const items = trackStream([quota('Eggs', ['ai-failed'])], CONFIG)
+    expect(items.map((i) => i.color)).toEqual([null, null])
+    expect(titles(items)).toEqual(['Unlabelled'])
+  })
+})
+
+describe('the period suffix on a chip', () => {
+  test('is two letters at most, one per period', () => {
+    expect(periodSuffix('today')).toBe('d')
+    expect(periodSuffix('this week')).toBe('wk')
+    expect(periodSuffix('this month')).toBe('mo')
+    expect(periodSuffix('this year')).toBe('yr')
+  })
+
+  test('is nothing at all when the period is not one we know', () => {
+    // A quota with no rule has no period; printing the raw string inside a chip
+    // would be worse than printing nothing.
+    expect(periodSuffix('every other Tuesday')).toBeNull()
+  })
+})

--- a/tests/behavioral/tr-track-stream.test.ts
+++ b/tests/behavioral/tr-track-stream.test.ts
@@ -12,7 +12,13 @@
  * depends on when it runs.
  */
 import { describe, test, expect } from 'vitest'
-import { trackStream, periodSuffix, type TrackStreamItem } from '@/lib/track'
+import {
+  trackStream,
+  periodSuffix,
+  trackStripeClass,
+  TRACK_NEUTRAL_CLASS,
+  type TrackStreamItem,
+} from '@/lib/track'
 import type { LabelConfig, Task } from '@/types'
 
 const quota = (title: string, labels: string[], rrule = 'FREQ=WEEKLY'): Task =>
@@ -46,7 +52,8 @@ const shape = (items: TrackStreamItem[]) =>
 describe('the Track panel streams its quotas by label', () => {
   test('a title opens each cluster, alphabetically, unlabelled last', () => {
     const items = trackStream(CORPUS, CONFIG)
-    expect(titles(items)).toEqual(['health', 'house', 'job-hunt', 'kids', 'Unlabelled'])
+    // "Other", not the Quotas page's "Unlabelled" — see NO_LABEL_NAME.
+    expect(titles(items)).toEqual(['health', 'house', 'job-hunt', 'kids', 'Other'])
     // Not "no label": the leftovers are a named group, and they sort last
     // however the names happen to fall.
     expect(items[items.length - 1]).toMatchObject({ kind: 'chip' })
@@ -66,7 +73,7 @@ describe('the Track panel streams its quotas by label', () => {
       '· Check for new certifications',
       'kids',
       '· Josie clean dishes (chore)',
-      'Unlabelled',
+      'Other',
       '· Beef For Kids',
       '· Eggs',
     ])
@@ -78,7 +85,7 @@ describe('the Track panel streams its quotas by label', () => {
   test('the first item is always a title, so nothing is orphaned', () => {
     expect(trackStream([quota('Eggs', [])], [])[0]).toMatchObject({
       kind: 'title',
-      name: 'Unlabelled',
+      name: 'Other',
       label: null,
     })
   })
@@ -110,10 +117,11 @@ describe('the colour a cluster is drawn in', () => {
     expect(items.every((i) => i.color === null)).toBe(true)
   })
 
-  test('is null for the unlabelled cluster even when a label is named ""', () => {
-    const items = trackStream([quota('Eggs', [])], [{ name: 'Unlabelled', color: 'red' }])
-    // "Unlabelled" is this panel's word for the gap, not a label anybody can
-    // colour by registering that name.
+  test('is null for the no-label cluster even when a label is named "Other"', () => {
+    const items = trackStream([quota('Eggs', [])], [{ name: 'Other', color: 'red' }])
+    // "Other" is this panel's word for the gap, not a label anybody can colour
+    // by registering that name — the cluster is keyed on a null label, not on
+    // the word.
     expect(items.map((i) => i.color)).toEqual([null, null])
   })
 
@@ -127,7 +135,7 @@ describe('the colour a cluster is drawn in', () => {
     // it must not pick up ai-failed's hard-wired red.
     const items = trackStream([quota('Eggs', ['ai-failed'])], CONFIG)
     expect(items.map((i) => i.color)).toEqual([null, null])
-    expect(titles(items)).toEqual(['Unlabelled'])
+    expect(titles(items)).toEqual(['Other'])
   })
 })
 
@@ -143,5 +151,24 @@ describe('the period suffix on a chip', () => {
     // A quota with no rule has no period; printing the raw string inside a chip
     // would be worse than printing nothing.
     expect(periodSuffix('every other Tuesday')).toBeNull()
+  })
+})
+
+describe('the stripe a chip is painted with', () => {
+  test("is the label colour's flat swatch", () => {
+    expect(trackStripeClass('blue')).toBe('bg-blue-500')
+    expect(trackStripeClass('orange')).toBe('bg-orange-500')
+  })
+
+  test('is neutral when there is no colour', () => {
+    expect(trackStripeClass(null)).toBe(TRACK_NEUTRAL_CLASS)
+  })
+
+  test('is neutral for GREEN, which already means "met" on these chips', () => {
+    // Settings lets a label be green like any other colour, and its chips stay
+    // green everywhere else. Only the stripe declines it: green on a chip that
+    // is not at its target would read as met.
+    expect(trackStripeClass('green')).toBe(TRACK_NEUTRAL_CLASS)
+    expect(trackStripeClass('green')).not.toBe('bg-green-500')
   })
 })

--- a/tests/e2e/track.spec.ts
+++ b/tests/e2e/track.spec.ts
@@ -82,40 +82,53 @@ test.describe('Track', () => {
       await expect(panel.getByRole('button', { name: 'Expand Track' })).toBeVisible()
       const night = panel.locator(`[data-track-chip="${nightId}"]`)
       await expect(night).toContainText('Date night')
-      await expect(night.locator('[data-track-count]')).toHaveText('0/1')
-      // One card per period, the word once on the card, never on a chip; each
-      // card has its own bar.
-      const monthCard = panel.locator('[data-track-period="month"]')
-      const weekCard = panel.locator('[data-track-period="week"]')
-      await expect(monthCard.getByRole('list', { name: 'month' })).toContainText('Date night')
-      await expect(weekCard.getByRole('list', { name: 'week' })).toContainText('Eggs for the kids')
-      await expect(weekCard.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0')
+      // The period is two letters on the chip's own count, since the panel
+      // groups by LABEL now and a label group mixes days, weeks and months.
+      await expect(night.locator('[data-track-count]')).toHaveText('0/1·mo')
+      // One card, one list: no period cards and no summed bar (a bar across
+      // mixed periods is meaningless — §5, Trent 2026-09-09).
+      await expect(panel.locator('[data-track-period]')).toHaveCount(0)
+      const stream = panel.getByRole('list', { name: 'Quotas' })
+      await expect(stream).toHaveCount(1)
+      await expect(stream).toContainText('Date night')
+      await expect(stream).toContainText('Eggs for the kids')
+      await expect(panel.getByRole('progressbar')).toHaveCount(0)
       await expect(panel.getByRole('button', { name: 'Expand Track' })).not.toContainText('this')
       await expect(panel.locator(`[data-track-row="${id}"]`)).toHaveCount(0)
       const chip = panel.locator(`[data-track-chip="${id}"]`)
       const chipCount = chip.locator('[data-track-count]')
-      await expect(chipCount).toHaveText('0/2')
+      await expect(chipCount).toHaveText('0/2·wk')
 
       // Tap: +1, with a toast whose Undo takes it back.
       await chip.click()
-      await expect(chipCount).toHaveText('1/2')
-      await expect(weekCard.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '1')
+      await expect(chipCount).toHaveText('1/2·wk')
       const toast = page
         .locator('[data-sonner-toast]')
         .filter({ hasText: 'Logged one for \u201cEggs for the kids\u201d \u00b7 1/2' })
       await expect(toast).toBeVisible()
       await toast.getByRole('button', { name: 'Undo' }).click()
-      await expect(chipCount).toHaveText('0/2')
+      await expect(chipCount).toHaveText('0/2·wk')
+      // ...and the server ends where the chip says it does. The +1 and the −1
+      // that takes it back are one gesture apart, so they used to be in flight
+      // together; applied in the wrong order the server's clamp-at-zero ate the
+      // −1 and left 1 behind, which nothing showed until the next reload.
+      // `useTrackProgress` queues a task's requests for exactly this.
+      await expect
+        .poll(async () => {
+          const res = await page.request.get(`/api/tasks/${id}`)
+          return (await res.json()).data.progress_current
+        })
+        .toBe(0)
 
       // Subtracting: shift-click and right-click. A hold no longer subtracts —
       // since 2026-09-06 it opens the detail sheet, and the swipe took over −1.
       await chip.click()
       await chip.click()
-      await expect(chipCount).toHaveText('2/2')
+      await expect(chipCount).toHaveText('2/2·wk')
       await chip.click({ modifiers: ['Shift'] })
-      await expect(chipCount).toHaveText('1/2')
+      await expect(chipCount).toHaveText('1/2·wk')
       await chip.click({ button: 'right' })
-      await expect(chipCount).toHaveText('0/2')
+      await expect(chipCount).toHaveText('0/2·wk')
 
       // A hold opens a popover anchored to the chip — the shape Trent asked
       // for on 2026-09-06 ("still the same concept but not hover"). It reads,
@@ -125,7 +138,7 @@ test.describe('Track', () => {
       await expect(pop).toBeVisible()
       await expect(pop).toContainText('Never yet')
       await expect(pop.getByRole('textbox')).toHaveCount(0)
-      await expect(chipCount).toHaveText('0/2')
+      await expect(chipCount).toHaveText('0/2·wk')
 
       // Open is the answer to "how do I even edit the Track items": a quota is
       // an ordinary task, and it gets its OWN editor — no due date, no snooze
@@ -191,11 +204,17 @@ test.describe('Track', () => {
       await plus.click()
       await expect(count).toContainText('3 / 2')
 
-      // The task itself is still open — progress is not completion.
-      const res = await page.request.get(`/api/tasks/${id}`)
-      const task = (await res.json()).data
-      expect(task.done).toBe(false)
-      expect(task.progress_current).toBe(3)
+      // The task itself is still open — progress is not completion. Polled, not
+      // read once: the count on screen is optimistic and the +1 behind it is
+      // still on the wire (`useTrackProgress` sends a task's logs one at a
+      // time), so a single read races the request it is checking on.
+      await expect
+        .poll(async () => {
+          const res = await page.request.get(`/api/tasks/${id}`)
+          const task = (await res.json()).data
+          return { done: task.done, progress_current: task.progress_current }
+        })
+        .toEqual({ done: false, progress_current: 3 })
     } finally {
       await closeTrack(page)
       await deleteTasks(page, [id, nightId])
@@ -241,6 +260,107 @@ test.describe('Track', () => {
       await expect(after.getByRole('button', { name: 'Move to Trash' })).toBeVisible()
     } finally {
       await deleteTasks(page, [id])
+    }
+  })
+
+  /**
+   * §5, Trent 2026-09-09, choosing variation G of the `track-by-label` mockup:
+   * the panel groups by LABEL and draws the whole thing as one wrapping row,
+   * so a cluster's heading is a PEER of the chips rather than a box around
+   * them. That is the load-bearing part — a heading that is its own container
+   * would start a new line, which is the height the layout was chosen to save
+   * — so it is asserted as DOM shape (same flex parent, one wrapping list),
+   * never as pixel positions.
+   */
+  test('quotas stream under inline label titles, in label order, unlabelled last', async ({
+    authenticatedPage: page,
+  }) => {
+    const ids: number[] = []
+    try {
+      // "dev" and "work" are registered by the seed, and sort in that order.
+      const devId = await createTask(page, {
+        title: 'Probe stream dev quota',
+        progress_target: 2,
+        rrule: 'FREQ=WEEKLY',
+        labels: ['dev'],
+        create_label: true,
+      })
+      const workId = await createTask(page, {
+        title: 'Probe stream work quota',
+        progress_target: 3,
+        rrule: 'FREQ=DAILY',
+        labels: ['work'],
+        create_label: true,
+      })
+      const bareId = await createTask(page, {
+        title: 'Probe stream bare quota',
+        progress_target: 1,
+        is_tracked: true,
+        rrule: 'FREQ=MONTHLY',
+      })
+      ids.push(devId, workId, bareId)
+
+      await page.goto('/')
+      const panel = page.getByRole('region', { name: 'Track' })
+      await expect(panel.getByRole('button', { name: 'Expand Track' })).toBeVisible()
+      const stream = panel.getByRole('list', { name: 'Quotas' })
+
+      // One list holds every cluster: no card, no sub-list, per label.
+      await expect(stream).toHaveCount(1)
+      for (const key of ['dev', 'work', 'unlabelled']) {
+        await expect(stream.locator(`[data-track-cluster="${key}"]`)).toBeVisible()
+      }
+
+      // A title and the chips it introduces are siblings — direct children of
+      // the same wrapping list — which is what lets the title attach after the
+      // previous cluster's last chip instead of forcing a break.
+      for (const [key, id] of [
+        ['dev', devId],
+        ['work', workId],
+        ['unlabelled', bareId],
+      ] as const) {
+        await expect(stream.locator(`:scope > li[data-track-cluster="${key}"]`)).toHaveCount(1)
+        await expect(stream.locator(`:scope > li:has([data-track-chip="${id}"])`)).toHaveCount(1)
+      }
+
+      // ...and that parent is the wrapping flex row itself, so a title can
+      // never be pushed onto a line of its own.
+      expect(
+        await stream.evaluate((el) => {
+          const s = getComputedStyle(el)
+          return { display: s.display, wrap: s.flexWrap }
+        }),
+      ).toEqual({ display: 'flex', wrap: 'wrap' })
+
+      // Alphabetical by label, and the unlabelled cluster is the leftovers —
+      // last however the names happen to sort.
+      const order = await stream
+        .locator('[data-track-cluster]')
+        .evaluateAll((els) => els.map((el) => el.getAttribute('data-track-cluster')))
+      expect(order.indexOf('dev')).toBeLessThan(order.indexOf('work'))
+      expect(order[order.length - 1]).toBe('unlabelled')
+
+      // Each quota is in the stream exactly once, and carries its own period
+      // as a suffix now that no card names one.
+      for (const id of ids) await expect(stream.locator(`[data-track-chip="${id}"]`)).toHaveCount(1)
+      await expect(stream.locator(`[data-track-chip="${devId}"] [data-track-count]`)).toHaveText(
+        '0/2\u00b7wk',
+      )
+      await expect(stream.locator(`[data-track-chip="${workId}"] [data-track-count]`)).toHaveText(
+        '0/3\u00b7d',
+      )
+      await expect(stream.locator(`[data-track-chip="${bareId}"] [data-track-count]`)).toHaveText(
+        '0/1\u00b7mo',
+      )
+
+      // Expanded, the same clusters become headings over the full rows — the
+      // grouping does not vanish when the panel opens.
+      await openTrack(page)
+      await expect(panel.locator(`[data-track-row="${devId}"]`)).toBeVisible()
+      await expect(panel.locator('[data-track-cluster="dev"]')).toBeVisible()
+      await closeTrack(page)
+    } finally {
+      await deleteTasks(page, ids)
     }
   })
 

--- a/tests/e2e/track.spec.ts
+++ b/tests/e2e/track.spec.ts
@@ -4,7 +4,7 @@
  * closing the task.
  */
 import { test, expect } from './fixtures'
-import type { Page } from '@playwright/test'
+import type { Page, Response } from '@playwright/test'
 
 async function createTask(page: Page, body: Record<string, unknown>): Promise<number> {
   const res = await page.request.post('/api/tasks', { data: body })
@@ -99,7 +99,27 @@ test.describe('Track', () => {
       const chipCount = chip.locator('[data-track-count]')
       await expect(chipCount).toHaveText('0/2·wk')
 
-      // Tap: +1, with a toast whose Undo takes it back.
+      // Tap: +1, with a toast whose Undo takes it back — and the server ends
+      // where the chip says it does.
+      //
+      // This is the ordering guard, so the two clicks must stay BACK TO BACK:
+      // nothing here may wait for the +1 to reach the server, because the bug
+      // it pins only exists while the +1 and the −1 are in flight together.
+      // From a count of 0, applied in the wrong order, the server's
+      // clamp-at-zero ate the −1 and left 1 behind — invisible until the next
+      // reload, since the optimistic display shows the local value throughout.
+      // `useTrackProgress` queues a task's logs for exactly this.
+      //
+      // Counting the responses rather than polling the count to 0 matters: the
+      // task starts AT 0, so a poll would be satisfied by its own first read,
+      // before either mutation had landed, and would pass on the broken code.
+      // Waiting for both logs to come back and then reading once cannot.
+      let settledLogs = 0
+      const countLogs = (r: Response) => {
+        if (r.request().method() === 'POST' && r.url().endsWith(`/api/tasks/${id}/progress`))
+          settledLogs++
+      }
+      page.on('response', countLogs)
       await chip.click()
       await expect(chipCount).toHaveText('1/2·wk')
       const toast = page
@@ -108,17 +128,11 @@ test.describe('Track', () => {
       await expect(toast).toBeVisible()
       await toast.getByRole('button', { name: 'Undo' }).click()
       await expect(chipCount).toHaveText('0/2·wk')
-      // ...and the server ends where the chip says it does. The +1 and the −1
-      // that takes it back are one gesture apart, so they used to be in flight
-      // together; applied in the wrong order the server's clamp-at-zero ate the
-      // −1 and left 1 behind, which nothing showed until the next reload.
-      // `useTrackProgress` queues a task's requests for exactly this.
-      await expect
-        .poll(async () => {
-          const res = await page.request.get(`/api/tasks/${id}`)
-          return (await res.json()).data.progress_current
-        })
-        .toBe(0)
+      await expect.poll(() => settledLogs).toBe(2)
+      page.off('response', countLogs)
+      expect(
+        (await (await page.request.get(`/api/tasks/${id}`)).json()).data.progress_current,
+      ).toBe(0)
 
       // Subtracting: shift-click and right-click. A hold no longer subtracts —
       // since 2026-09-06 it opens the detail sheet, and the swipe took over −1.
@@ -267,12 +281,14 @@ test.describe('Track', () => {
    * §5, Trent 2026-09-09, choosing variation G of the `track-by-label` mockup:
    * the panel groups by LABEL and draws the whole thing as one wrapping row,
    * so a cluster's heading is a PEER of the chips rather than a box around
-   * them. That is the load-bearing part — a heading that is its own container
-   * would start a new line, which is the height the layout was chosen to save
-   * — so it is asserted as DOM shape (same flex parent, one wrapping list),
-   * never as pixel positions.
+   * them — asserted as DOM shape (same flex parent, one wrapping list).
+   *
+   * Amended the same day, after Trent saw it on dev: a title landing mid-row
+   * after the previous cluster's last chip read as confusing rather than
+   * compact, so every title now starts its own row. That is measured as an
+   * equality — the title's left edge IS the list's left edge — not a tolerance.
    */
-  test('quotas stream under inline label titles, in label order, unlabelled last', async ({
+  test('each label title starts a row, in label order, the no-label cluster last', async ({
     authenticatedPage: page,
   }) => {
     const ids: number[] = []
@@ -307,7 +323,9 @@ test.describe('Track', () => {
 
       // One list holds every cluster: no card, no sub-list, per label.
       await expect(stream).toHaveCount(1)
-      for (const key of ['dev', 'work', 'unlabelled']) {
+      // '' is the no-label cluster's key: a label name is validated non-empty,
+      // so it is the one key no real label can collide with.
+      for (const key of ['dev', 'work', '']) {
         await expect(stream.locator(`[data-track-cluster="${key}"]`)).toBeVisible()
       }
 
@@ -317,7 +335,7 @@ test.describe('Track', () => {
       for (const [key, id] of [
         ['dev', devId],
         ['work', workId],
-        ['unlabelled', bareId],
+        ['', bareId],
       ] as const) {
         await expect(stream.locator(`:scope > li[data-track-cluster="${key}"]`)).toHaveCount(1)
         await expect(stream.locator(`:scope > li:has([data-track-chip="${id}"])`)).toHaveCount(1)
@@ -338,7 +356,45 @@ test.describe('Track', () => {
         .locator('[data-track-cluster]')
         .evaluateAll((els) => els.map((el) => el.getAttribute('data-track-cluster')))
       expect(order.indexOf('dev')).toBeLessThan(order.indexOf('work'))
-      expect(order[order.length - 1]).toBe('unlabelled')
+      // The panel calls the no-label group "Other"; the Quotas page still says
+      // "Unlabelled", which has a card header with room for the longer word.
+      await expect(stream.locator('[data-track-cluster=""]')).toHaveText('Other')
+      expect(order[order.length - 1]).toBe('')
+
+      // EVERY title starts its own row (Trent, 2026-09-09): its left edge is
+      // the list's own left edge, and no chip shares that row to its left. A
+      // zero-height full-basis <li> before each title is what forces the wrap.
+      // Measured as equalities, not tolerances: an offset of exactly 0, and a
+      // count of exactly 0 chips overlapping the title's band to its left.
+      const rowStarts = await stream.evaluate((ul) => {
+        const listLeft = ul.getBoundingClientRect().left
+        const chips = [...ul.querySelectorAll('[data-track-chip]')].map((c) =>
+          c.getBoundingClientRect(),
+        )
+        return [...ul.querySelectorAll('[data-track-cluster]')].map((el) => {
+          const r = el.getBoundingClientRect()
+          return {
+            cluster: el.getAttribute('data-track-cluster'),
+            offsetFromListLeft: r.left - listLeft,
+            // Vertical overlap, not centre equality — a boolean about boxes,
+            // with no pixel slack in it.
+            chipsLeftOfItOnItsRow: chips.filter(
+              (c) => c.bottom > r.top && c.top < r.bottom && c.right <= r.left,
+            ).length,
+          }
+        })
+      })
+      expect(rowStarts.length).toBe(3)
+      for (const t of rowStarts) {
+        expect({ cluster: t.cluster, offset: t.offsetFromListLeft }).toEqual({
+          cluster: t.cluster,
+          offset: 0,
+        })
+        expect({ cluster: t.cluster, chipsBefore: t.chipsLeftOfItOnItsRow }).toEqual({
+          cluster: t.cluster,
+          chipsBefore: 0,
+        })
+      }
 
       // Each quota is in the stream exactly once, and carries its own period
       // as a suffix now that no card names one.


### PR DESCRIPTION
## Summary

The Track panel used to be one card per period — DAY / WEEK / MONTH, each with a summed progress bar. Trent picked **variation G** of the `track-by-label` mockup, with **D's stripe**: the label is the question a quota answers to ("there's a bunch of stuff for the kids and there are other things"), and a bar across a group that mixes days, weeks and months is "2 a day + 3 a week + 1 a month = 7" — a number nobody can act on. The Quotas page dropped that bar for the same reason when it moved to labels.

So the panel is now **one card holding one wrapping row**:

- A cluster opens with its label in the panel's own small uppercase run, which is a **plain flex item** — it attaches after the previous cluster's last chip and wraps with everything else, so it can never force a line break. That is what makes this the shortest of the seven layouts drawn.
- The period moves onto the chip as a two-letter suffix (`0/2·d`, `0/3·wk`, `0/1·mo`), via a new `suffix` column on `QUOTA_PERIODS` rather than a second FREQ→period map.
- Each chip gets a **3px stripe** in its label's colour, and the title carries the same colour as a dot. The chip's radius drops from a full pill to 10px so the stripe reads as a stripe, not a crescent.
- Colour comes from `label_config` — where every other label colour in the app comes from (`getLabelClasses`, and `QuotasView` calls it "its registry colour"). A label nobody has coloured, and the unlabelled cluster, get a **neutral** one; no palette is invented in code. Green stays reserved for "met".
- **Expanded**, the same clusters in the same order become headings over the full rows. Not in the mockup — that was about the folded state — but the alternative was for the grouping to vanish the moment the panel opens, leaving a flat list of 19 rows with no organising idea.

`QuotasView` and the iOS widget are untouched. `groupByPeriod` is unchanged and kept (its tests still cover it), but it now has **no caller in `src/`** — same for `trackSummary`.

### The helper

`trackStream(quotas, labelConfig)` in `src/lib/track.ts` returns a **flat** `{kind:'title'|'chip', …}` list — `groupByLabel`'s order (case-insensitive alphabetical, "Unlabelled" last), with the colour resolved once per cluster and copied onto its chips. Flat rather than nested because a title that is its own container would put a wrap boundary between clusters, which is exactly what the layout exists to avoid. `getLabelColor()` is the new seam in `label-colors.ts`; `getLabelClasses()` now goes through it.

### Also in this diff: `useTrackProgress` sends a task's logs one at a time

A reviewer opening a layout PR should know why a hook is in the diff.

A task's progress requests used to fire **concurrently**, and the server clamps at zero (`incrementProgress`: a correction may undo a mis-log, not manufacture history). So a `+1` and the `−1` that takes it back, in flight together and applied in the wrong order, clamp the `−1` away and leave the count **one too high** — invisible until the next reload, because the optimistic display shows the local value while anything is in flight. Tap-then-Undo is the toast's own advertised gesture, so this is the main path, not an edge case. The hook's own doc comment already claimed "the server applies them in order"; nothing enforced it. Now the requests queue per task.

**This is inferred from the failure signature, not captured with instrumentation.** The `:59` E2E test failed with the row reading `1 / 2` after a reload; the server clamps at 0; and once the period-card progressbar assertion went away (it had no target left), the `+1` and its Undo click were the only concurrent pair with no assertion between them. A probe run reported `server=0` at every checkpoint and passed — adding requests changed the timing — and the failure-only probe never caught a failure. So: consistent with, not proven.

**Trade-off:** a stalled first request now delays the network call behind it. The optimistic count is unaffected — it still moves on the tap — so perceived latency is unchanged; only settling is serialized.

## Test plan

- [x] Quick check passes — type-check clean, lint 0 errors / **99 warnings (same as `main`, none added)**, 1071 behavioral tests
- [x] Integration tests pass — 260
- [x] E2E tests pass — 63 (`tests/e2e/track.spec.ts` updated for the new DOM; one new test pins cluster order, "Unlabelled" last, and that a title run is a **direct child of the same wrapping flex list** as the chips — DOM shape, not pixels)
- [x] New behavioral tests — `tests/behavioral/tr-track-stream.test.ts`, 12 tests: order, title-before-first-chip-of-each-cluster, Unlabelled last, within-cluster order frozen, colour with and without a configured colour, case-insensitive match, reserved `ai-*` labels stay neutral, and the period suffixes
- [x] Screenshots — desktop 1280×800 and phone 375×812, chips and rows, verified on dev against the real 19-quota corpus (health 6, house 2, job-hunt 1, kids 2, unlabelled 8): every quota appears exactly once, stripes carry the dev colours, `+1` still counts and opens nothing, no console errors/warnings and no failed requests on a settled page

Panel height at 375px, chips state: **715px** (mockup measured 656px for plain G). The brief's G+D merge is wider than the mockup's G, which had neither a swatch on the title run nor a stripe on the chip: 5 × ~14px of swatch+gap and 19 × 2px of stripe padding is roughly a row and a half at phone width, and the app's content column is narrower than the mockup's 351px frame. Rows state at 375px is 1584px; desktop is 409px (chips) / 1043px (rows).

## Revision — after Trent saw it on dev

**Every label title now starts its own row.** "house" landing mid-row after a health chip read as confusing rather than compact. Still one card and one wrapping list — titles and chips are still peers, so the DOM shape is unchanged — but a zero-height, full-basis `<li>` before each title after the first forces the wrap, and the title keeps no left margin, so it sits flush with the card's left edge and its chips flow across from there. Chosen over `flex-basis:100%` on the title run itself, which would have put the title alone on its line with the chips below; the brief asked for the title *inline at the row start*. The break is layout only, so it lives in the component, not in `trackStream`. Cost: **761px** at 375px (was 715), 433px on desktop (was 409) — one extra row gap per cluster boundary.

**The no-label cluster is titled "Other"** in the panel. `QuotasView` keeps "Unlabelled" and is otherwise untouched — it has a card header with room for the longer word, where the panel's titles are inline at 11px.

### Review findings folded in

- **The race guard asserted nothing.** The task starts at 0, so polling the count to 0 was satisfied by the poller's own first read, before either mutation landed — it passed on the broken code too. It now waits for **both** logs to come back, then reads once. The two clicks stay **back to back**: waiting for the `+1` to settle would serialize the pair by test pacing and stop exercising the bug at all, which is why this counts responses rather than polling to 1 and then to 0.
- **Green collided with "met"**, and the panel's comment claimed it couldn't. `trackStripeClass()` declines green and falls back to neutral; Settings still offers it and the label's chips elsewhere are unchanged. Pinned in `tr-track-stream`.
- **Accessibility.** The deleted period card's `role="progressbar"` was the only announced progress in the folded state, and `aria-label` replaces a button's contents — so the chip's count and its `sr-only` period were never read. Both now live in the accessible name: `Log one more for "Eggs" — 0 of 2 this week`. The false comment and the pointless `sr-only` run are gone.
- **Cluster key is the empty string**, not the word `unlabelled`: a label may legally be named that and would have shared a key and a selector with the quotas that have no label. A label name is validated non-empty, so `""` is the one key no label can take.
- **`queue.current.catch(() => {}).then(...)`** — a throw from the catch block or the finally would otherwise poison the chain permanently, leaving every later tap moving the optimistic count and never reaching the server. The docstring now also says what queuing does cost: a tab close or hard reload mid-burst drops the un-sent tail (client navigation is fine).
- **A very long label truncates** at the card's edge instead of pushing out of it.
- **Stale comments corrected** — `QuotasView.tsx` (comment only), `periodShort`, `trackSummary`, `groupByPeriod`, and the panel's "nothing here is ever cut" (titles *do* ellipsise at phone width; counts never do). `groupByPeriod` and `trackSummary` now say in their docstrings that they have no caller in `src/` and are kept for their tests and a future period view.

### Re-verified

Type-check clean, lint 0 errors / **99 warnings (unchanged)**, behavioral **1074**, integration **260**, E2E **63**. The new row-start assertion is load-bearing: with the break element disabled the title measures 268.8px from the list's left edge and the test fails. Dev re-deployed and re-checked at 1280×800 and 375×812 (`.tmp/stream2-*`): all five titles at `offsetFromListLeft === 0` with zero chips to their left on their row, "Other" carrying the neutral swatch, 19 chips, `+1` still counting and opening nothing, no console errors/warnings and no failed requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
