### PR TITLE
fix(ios): the Track widget paces quotas from the period anchor, not due_at

### DIFF
--- a/ios/OpenTaskWidgets/SampleData.swift
+++ b/ios/OpenTaskWidgets/SampleData.swift
@@ -20,15 +20,14 @@ enum SampleData {
         return DateHelpers.formatISO(calendar.date(from: comps) ?? Date())
     }
 
-    /// A period boundary `days` out. Quota samples need a real `due_at` *and*
-    /// rrule or `TrackTimeline` has no period to measure pace against, and the
-    /// gallery card would show quotas with no pace tick at all.
-    private static func inDays(_ days: Int, hour: Int = 21) -> String {
+    /// Local midnight `days` ago, as the UTC ISO 8601 string the API returns in
+    /// `progress_period_start`. A quota sample needs an anchor *and* an rrule or
+    /// `TrackTimeline` has no period to measure pace against, and the gallery
+    /// card would show quotas with no pace tick at all.
+    private static func periodStart(daysAgo days: Int) -> String {
         let calendar = Calendar.current
-        let day = calendar.date(byAdding: .day, value: days, to: Date()) ?? Date()
-        var comps = calendar.dateComponents([.year, .month, .day], from: day)
-        comps.hour = hour
-        return DateHelpers.formatISO(calendar.date(from: comps) ?? Date())
+        let day = calendar.date(byAdding: .day, value: -days, to: Date()) ?? Date()
+        return DateHelpers.formatISO(calendar.startOfDay(for: day))
     }
 
     // MARK: - Reminders
@@ -109,16 +108,29 @@ enum SampleData {
     /// Spread across the pace range on purpose: one behind, one comfortably
     /// ahead, one met, one overflowing, so the gallery card shows every state
     /// the widget can be in.
+    ///
+    /// No `due_at` — §5 quotas are dateless, and the period anchor is what pace
+    /// is measured from. The anchors are offsets from today rather than real
+    /// Monday/1st boundaries so each card keeps the state it was written to
+    /// show whatever day the gallery is opened on.
     static var trackedTasks: [TaskDTO] {
         [
-            TaskDTO(id: 301, projectId: 3, title: "Workout", priority: 2, dueAt: inDays(3),
-                    rrule: "FREQ=WEEKLY;BYDAY=SU", progressTarget: 4, progressCurrent: 1),
-            TaskDTO(id: 302, projectId: 3, title: "Read", priority: 0, dueAt: inDays(3),
-                    rrule: "FREQ=WEEKLY;BYDAY=SU", progressTarget: 3, progressCurrent: 2),
-            TaskDTO(id: 303, projectId: 1, title: "Walk the long way home", priority: 1, dueAt: inDays(1),
-                    rrule: "FREQ=DAILY", progressTarget: 2, progressCurrent: 2),
-            TaskDTO(id: 304, projectId: 2, title: "Deep work block", priority: 3, dueAt: inDays(5),
-                    rrule: "FREQ=WEEKLY;BYDAY=FR", progressTarget: 3, progressCurrent: 4),
+            // 5/7 of a week gone against 1 of 4 done: behind.
+            TaskDTO(id: 301, projectId: 3, title: "Workout", priority: 2,
+                    rrule: "FREQ=WEEKLY;BYDAY=SU", progressTarget: 4, progressCurrent: 1,
+                    progressPeriodStart: periodStart(daysAgo: 5)),
+            // 2/7 gone against 2 of 3 done: ahead.
+            TaskDTO(id: 302, projectId: 3, title: "Read", priority: 0,
+                    rrule: "FREQ=WEEKLY;BYDAY=SU", progressTarget: 3, progressCurrent: 2,
+                    progressPeriodStart: periodStart(daysAgo: 2)),
+            // Today's daily quota, already met.
+            TaskDTO(id: 303, projectId: 1, title: "Walk the long way home", priority: 1,
+                    rrule: "FREQ=DAILY", progressTarget: 2, progressCurrent: 2,
+                    progressPeriodStart: periodStart(daysAgo: 0)),
+            // Overflowing: 4 logged against a target of 3.
+            TaskDTO(id: 304, projectId: 2, title: "Deep work block", priority: 3,
+                    rrule: "FREQ=WEEKLY;BYDAY=FR", progressTarget: 3, progressCurrent: 4,
+                    progressPeriodStart: periodStart(daysAgo: 3)),
         ]
     }
 

--- a/ios/OpenTaskWidgets/TrackWidget.swift
+++ b/ios/OpenTaskWidgets/TrackWidget.swift
@@ -69,13 +69,19 @@ enum TrackTimeline {
     ///
     /// **Pace (§5)** is `fraction of target done − fraction of period elapsed`,
     /// both clamped to 0...1: 0 is exactly on pace, negative behind, positive
-    /// ahead. §5 anchors a quota to its rrule period and `due_at` is that
-    /// period's boundary, so the window is `[due − periodLength, due]` and
-    /// `periodLength` comes from the rule's `FREQ` × `INTERVAL`. Everything
-    /// else in an rrule (`BYDAY`, `BYMONTHDAY`) narrows *when* inside the
-    /// period, never how long it is, so it is ignored here on purpose.
+    /// ahead. The period is the window `[progress_period_start, that + one
+    /// period]`: the server anchors every quota to the local calendar boundary
+    /// its period began on and advances that anchor as each period closes, and
+    /// the length comes from the rule's `FREQ` × `INTERVAL`. Everything else in
+    /// an rrule (`BYDAY`, `BYMONTHDAY`) narrows *when* inside the period, never
+    /// how long it is, so it is ignored here on purpose.
     ///
-    /// Items with no rrule or no due date have no clock to be behind: they get
+    /// The anchor replaced `due_at`, which used to stand in for the period's
+    /// end. A quota is dateless as of §5 — `due_at` is always null on one now —
+    /// so that window had silently collapsed: every pace read nil, every quota
+    /// tied, and the ranking below quietly degraded to id order.
+    ///
+    /// Items with no rrule or no anchor have no clock to be behind: they get
     /// no pace, no tick, and sort last. Inventing a period for them would put a
     /// moving marker on a bar where it means nothing.
     ///
@@ -118,12 +124,22 @@ enum TrackTimeline {
     /// present), tap `+1` a hundred times and nothing moves. Nothing is lost —
     /// pace is still fully expressed by each row's bar and tick, which is where
     /// §5 says it belongs.
+    ///
+    /// A frozen order also has to be thrown away once when the pace maths
+    /// itself changes, or a wrong order outlives the fix that corrected it —
+    /// `WidgetStore.trackOrder` reads as empty when it was frozen under an
+    /// older `trackOrderVersion`, which lands on the re-rank branch below.
     static func orderedItems(from tasks: [TaskDTO], now: Date = Date()) -> [TrackItem] {
         let paced = pacedItems(from: tasks, now: now)
         let stored = WidgetStore.trackOrder
 
         guard !stored.isEmpty, Set(stored) == Set(paced.map(\.id)) else {
-            WidgetStore.trackOrder = paced.map(\.id)
+            // Only an order that some item's pace actually shaped may retire the
+            // version marker — see `WidgetStore.setTrackOrder`.
+            WidgetStore.setTrackOrder(
+                paced.map(\.id),
+                pacedByPeriod: paced.contains { $0.pace != nil }
+            )
             return paced
         }
 
@@ -135,47 +151,103 @@ enum TrackTimeline {
     }
 
     /// Fraction of the current period already gone, 0...1.
+    ///
+    /// The window is `[progress_period_start, that + one period]`. The anchor is
+    /// the server's (`src/core/tasks/period-rollover.ts`): the UTC instant the
+    /// current period began by the user's local calendar — Monday 00:00 for a
+    /// week, the 1st for a month, midnight for a day — moved forward one period
+    /// at a time by the rollover job, which is the same moment it zeroes
+    /// `progress_current`. So the tick and the count always describe the same
+    /// period.
+    ///
+    /// No anchor means no pace, and there is deliberately NO fallback to
+    /// `due_at`: a quota is dateless (§5), so any date still sitting on one is a
+    /// leftover from before that rule, and pacing from it is precisely the bug
+    /// this replaced.
     static func elapsedFraction(for task: TaskDTO, now: Date = Date()) -> Double? {
-        guard let end = task.dueDate, let length = periodLength(rrule: task.rrule), length > 0 else {
+        guard let start = task.periodStartDate,
+              let end = periodEnd(rrule: task.rrule, from: start)
+        else {
             return nil
         }
-        let start = end.addingTimeInterval(-length)
+        let length = end.timeIntervalSince(start)
+        guard length > 0 else { return nil }
         return min(max(now.timeIntervalSince(start) / length, 0), 1)
     }
 
-    /// Period length implied by an rrule's `FREQ` and `INTERVAL`.
+    /// The instant the period that began at `start` ends.
     ///
-    /// Months and years are approximated (30 / 365 days). Over a period that
-    /// long the tick moves by a fraction of a percent per day, so calendar
-    /// exactness would buy nothing an eye could resolve.
+    /// Calendar arithmetic rather than `start + periodLength`, now that a real
+    /// anchor makes exactness free: the flat 30-day month is visibly wrong at
+    /// the short end — a monthly quota in February would divide 28 days by 30
+    /// and its tick would stop at 93%, never reaching the end of a period that
+    /// had already ended. It also matches the server, which advances this very
+    /// anchor in calendar units in the user's timezone, and it keeps a
+    /// daily/weekly period honest across a DST change. `periodLength` stays as
+    /// the fallback for the case where the calendar cannot answer.
+    static func periodEnd(rrule: String?, from start: Date) -> Date? {
+        guard let period = periodComponents(rrule: rrule) else { return nil }
+        if let end = Calendar.current.date(byAdding: period.unit, value: period.count, to: start) {
+            return end
+        }
+        guard let length = periodLength(rrule: rrule), length > 0 else { return nil }
+        return start.addingTimeInterval(length)
+    }
+
+    /// The period as calendar units — `.day × 7` for a week, so a `WEEKLY`
+    /// rule never depends on where the locale puts the start of its week.
+    static func periodComponents(rrule: String?) -> (unit: Calendar.Component, count: Int)? {
+        guard let rule = parseFrequency(rrule) else { return nil }
+        switch rule.freq {
+        case "HOURLY": return (.hour, rule.interval)
+        case "DAILY": return (.day, rule.interval)
+        case "WEEKLY": return (.day, 7 * rule.interval)
+        case "MONTHLY": return (.month, rule.interval)
+        case "YEARLY": return (.year, rule.interval)
+        default: return nil
+        }
+    }
+
+    /// Period length implied by an rrule's `FREQ` and `INTERVAL`, as a flat
+    /// interval — the fallback path of `periodEnd` and nothing else.
+    ///
+    /// Months and years are approximated here (30 / 365 days), which is why it
+    /// is the fallback and not the measure.
     static func periodLength(rrule: String?) -> TimeInterval? {
+        guard let rule = parseFrequency(rrule) else { return nil }
+        let day: TimeInterval = 86_400
+        switch rule.freq {
+        case "HOURLY": return 3_600 * Double(rule.interval)
+        case "DAILY": return day * Double(rule.interval)
+        case "WEEKLY": return day * 7 * Double(rule.interval)
+        case "MONTHLY": return day * 30 * Double(rule.interval)
+        case "YEARLY": return day * 365 * Double(rule.interval)
+        default: return nil
+        }
+    }
+
+    /// `FREQ` and `INTERVAL` out of an rrule; everything else is ignored.
+    private static func parseFrequency(_ rrule: String?) -> (freq: String, interval: Int)? {
         guard let rrule, !rrule.isEmpty else { return nil }
 
         // The server writes bare `FREQ=WEEKLY;BYDAY=MO` (see
         // `src/core/recurrence/rrule-builder.ts`); the `RRULE:` prefix is
         // stripped defensively in case a payload ever carries the iCal form.
-        var freq: Substring?
+        var freq: String?
         var interval = 1
         let body = rrule.uppercased().replacingOccurrences(of: "RRULE:", with: "")
         for part in body.split(separator: ";") {
             let pair = part.split(separator: "=", maxSplits: 1)
             guard pair.count == 2 else { continue }
             switch pair[0].trimmingCharacters(in: .whitespaces) {
-            case "FREQ": freq = pair[1]
+            case "FREQ": freq = String(pair[1])
             case "INTERVAL": interval = max(Int(pair[1]) ?? 1, 1)
             default: break
             }
         }
 
-        let day: TimeInterval = 86_400
-        switch freq {
-        case "HOURLY": return 3_600 * Double(interval)
-        case "DAILY": return day * Double(interval)
-        case "WEEKLY": return day * 7 * Double(interval)
-        case "MONTHLY": return day * 30 * Double(interval)
-        case "YEARLY": return day * 365 * Double(interval)
-        default: return nil
-        }
+        guard let freq else { return nil }
+        return (freq, interval)
     }
 
     /// The quota the 2×2 shows: the user's chevron choice while that item still

--- a/ios/OpenTaskWidgets/WidgetStore.swift
+++ b/ios/OpenTaskWidgets/WidgetStore.swift
@@ -397,8 +397,25 @@ enum WidgetStore {
     // MARK: - Track row order
 
     private static let trackOrderKey = "widget.track.order"
+    private static let trackOrderVersionKey = "widget.track.orderVersion"
 
-    /// The quota id order the list families last rendered.
+    /// The pace algorithm the stored order was ranked under.
+    ///
+    /// Freezing an order (below) means a WRONG one survives the fix that
+    /// corrects it: pace used to be measured from a quota's `due_at`, §5 then
+    /// made quotas dateless, and every pace silently became nil — so the frozen
+    /// order on an existing install is the tie-break, plain id order. Bumping
+    /// this discards such an order exactly once. Version 1 never wrote the key,
+    /// so it reads back as 0 and mismatches on the first pass after the upgrade.
+    ///
+    /// Bump it whenever a change to `TrackTimeline`'s maths would rank the same
+    /// quotas differently. Not for anything else — this is a one-time reset, and
+    /// the freeze it interrupts exists so a `+1` never slides a row out from
+    /// under the finger that tapped it.
+    static let trackOrderVersion = 2
+
+    /// The quota id order the list families last rendered, or empty when it was
+    /// frozen under a different `trackOrderVersion`.
     ///
     /// Persisted because pace is a MOVING target and pace was the sort key:
     /// logging progress changes pace, so re-sorting every reload rearranged the
@@ -408,7 +425,29 @@ enum WidgetStore {
     /// changes; who is behind is already visible in every row's bar and tick, so
     /// nothing is lost by holding the order still.
     static var trackOrder: [Int] {
-        get { (defaults?.array(forKey: trackOrderKey) as? [Int]) ?? [] }
-        set { defaults?.set(newValue, forKey: trackOrderKey) }
+        guard let defaults, defaults.integer(forKey: trackOrderVersionKey) == trackOrderVersion
+        else {
+            return []
+        }
+        return (defaults.array(forKey: trackOrderKey) as? [Int]) ?? []
+    }
+
+    /// Freeze a row order, stamping the version only if pace actually shaped it.
+    ///
+    /// `pacedByPeriod` is the whole point of the parameter, and it is why the
+    /// stamp is not simply part of the setter. The first timeline pass after an
+    /// upgrade can easily render from the OLD build's cached payload — a failed
+    /// fetch, or the cache-only fast path a recent tap takes — and those encoded
+    /// tasks carry no `progress_period_start` at all, so every pace reads nil
+    /// and the ranking degrades to id order. Stamping THAT would retire the
+    /// version marker against a list the new maths never touched, re-freezing
+    /// the exact order the bump exists to discard. Withholding the stamp costs
+    /// one extra re-rank per pass until a fetch with real anchors lands, and
+    /// re-ranking an all-nil list changes nothing on screen.
+    static func setTrackOrder(_ ids: [Int], pacedByPeriod: Bool) {
+        defaults?.set(ids, forKey: trackOrderKey)
+        if pacedByPeriod {
+            defaults?.set(trackOrderVersion, forKey: trackOrderVersionKey)
+        }
     }
 }

--- a/ios/Shared/OpenTaskModels.swift
+++ b/ios/Shared/OpenTaskModels.swift
@@ -35,6 +35,16 @@ struct TaskDTO: Codable, Identifiable, Hashable {
     /// `var` alone among the fields: `withOptimisticIncrement()` below needs to
     /// bump it on a value-type copy. Nothing mutates the decoded instance.
     var progressCurrent: Int
+    /// UTC ISO 8601 — the instant this quota's CURRENT period began, or nil for
+    /// anything that isn't a quota (and for a quota the server's rollover job
+    /// has not anchored yet).
+    ///
+    /// The anchor is the user's local calendar boundary — Monday 00:00 for a
+    /// week, the 1st for a month, midnight for a day — advanced one period at a
+    /// time as each period closes (`src/core/tasks/period-rollover.ts`). It is
+    /// the only thing that says where a quota is in its period: §5 quotas carry
+    /// no due date at all.
+    let progressPeriodStart: String?
     /// The server's explicit "this is a quota" flag. It exists because a quota
     /// whose target is 1 ("date night, once a month") is indistinguishable from
     /// an ordinary task by target alone. Read it through `isTracked`, not
@@ -53,6 +63,7 @@ struct TaskDTO: Codable, Identifiable, Hashable {
         case anchorTime = "anchor_time"
         case progressTarget = "progress_target"
         case progressCurrent = "progress_current"
+        case progressPeriodStart = "progress_period_start"
         case trackedFlag = "is_tracked"
         case isReminder = "is_reminder"
         case labels
@@ -69,6 +80,7 @@ struct TaskDTO: Codable, Identifiable, Hashable {
         anchorTime = try c.decodeIfPresent(String.self, forKey: .anchorTime)
         progressTarget = try c.decodeIfPresent(Int.self, forKey: .progressTarget) ?? 1
         progressCurrent = try c.decodeIfPresent(Int.self, forKey: .progressCurrent) ?? 0
+        progressPeriodStart = try c.decodeIfPresent(String.self, forKey: .progressPeriodStart)
         trackedFlag = try c.decodeIfPresent(Bool.self, forKey: .trackedFlag) ?? false
         isReminder = try c.decodeIfPresent(Bool.self, forKey: .isReminder) ?? false
         labels = try c.decodeIfPresent([String].self, forKey: .labels) ?? []
@@ -86,6 +98,7 @@ struct TaskDTO: Codable, Identifiable, Hashable {
         anchorTime: String? = nil,
         progressTarget: Int = 1,
         progressCurrent: Int = 0,
+        progressPeriodStart: String? = nil,
         trackedFlag: Bool = false,
         isReminder: Bool = false,
         labels: [String] = []
@@ -99,6 +112,7 @@ struct TaskDTO: Codable, Identifiable, Hashable {
         self.anchorTime = anchorTime
         self.progressTarget = progressTarget
         self.progressCurrent = progressCurrent
+        self.progressPeriodStart = progressPeriodStart
         self.trackedFlag = trackedFlag
         self.isReminder = isReminder
         self.labels = labels
@@ -107,6 +121,14 @@ struct TaskDTO: Codable, Identifiable, Hashable {
     var dueDate: Date? {
         guard let dueAt else { return nil }
         return DateHelpers.parseISO(dueAt)
+    }
+
+    /// Start of the quota's current period, parsed. Nil is meaningful: it means
+    /// "no clock to be measured against", and nothing may substitute `dueDate`
+    /// for it — see `TrackTimeline.elapsedFraction`.
+    var periodStartDate: Date? {
+        guard let progressPeriodStart else { return nil }
+        return DateHelpers.parseISO(progressPeriodStart)
     }
 
     /// §5: a task is a quota if the server flagged it as one, or if its target


### PR DESCRIPTION
## What

The Track widget's pace maths now reads the server's period anchor (`progress_period_start`) instead of `due_at`. This is the Swift follow-up #18 flagged as pending.

## Why

PR #18 made a quota dateless. `TrackTimeline.elapsedFraction` measured the period as `[due_at − periodLength, due_at]`, so with `due_at` null on every quota that window collapsed:

- `elapsedFraction` returned nil for all of them — no pace tick on any ring or bar.
- `isMoreBehind` tied on every pair, so the row order and the 2×2's default selection fell through to the id tie-break. "Most behind pace first" had quietly become "lowest id first".

The server publishes the real anchor already: `progress_period_start` is the UTC instant the current period began by the user's local calendar (Monday 00:00 for a week, the 1st for a month, midnight for a day), advanced by the rollover job at the same moment it zeroes `progress_current` — so the tick and the count always describe the same period.

## How

- **`TaskDTO`** decodes `progress_period_start`, with `periodStartDate` alongside `dueDate`. The key is in `CodingKeys`, so it round-trips through the App Group payload cache the widget re-encodes into.
- **The pace window** is `[periodStart, periodStart + one period]`. No fallback to `due_at`: pacing a dateless quota from a leftover date is the bug this replaces.
- **The period end is calendar arithmetic** (`Calendar.current.date(byAdding:)`), not the old flat 30/365-day approximation. The approximation was visibly wrong at the short end — a monthly quota in February divided 28 days by 30, so its tick stopped at 93% and never reached the end of a period that had already ended. Calendar units also mirror the server, which advances this same anchor with luxon calendar units, and they keep a daily/weekly period honest across a DST change. `periodLength` stays as the fallback for when the calendar cannot answer.
- **`WidgetStore.trackOrderVersion`** discards a stored row order once when the pace maths changes. Without it this fix stays invisible on a phone that already has the widget: `orderedItems` re-ranks only when the set of quota ids changes, so the id-order frozen while every pace was nil would outlive the correction. The version is stamped only by an order that some item's pace actually shaped — a first pass rendering the *old* build's cached payload (which carries no anchors) cannot re-freeze the same wrong order. The freeze itself is untouched: a `+1` still never slides a row out from under the finger.
- **Sample quotas** carry anchors and no due date, so the gallery card shows the four pace states again (behind / ahead / met / overflowing) instead of four tickless bars.

No label grouping, colour, or widget-kind changes. Nothing outside `ios/`.

## How verified

- `cd ios && xcodegen` regenerates the canonical project cleanly; `make-sim-spec.py --check` reports `project-sim.yml` up to date.
- `build_sim` (iPhone 17 Pro, scheme `OpenTask`, which builds the widget extension) **succeeds**, with all four changed files compiled and **zero new warnings** — the only two warnings in the log are the pre-existing `appintentsmetadataprocessor` notices.
- Premise checked against production data (read-only query): of the 21 open quotas, **21 have `progress_period_start`, 0 have a `due_at`**, and all 21 have an rrule — so every one of them scored a nil pace under the old window, and every one of them gets a real pace under the new one. Anchors land where the rollover job says they should (`2026-09-07T05:00:00.000Z` for a weekly = Monday 00:00 local; `2026-09-01T05:00:00.000Z` for a monthly), and that fractional-second ISO form parses through `DateHelpers.parseISO`.
- There is no iOS test suite; CI here runs the web suites, which this change does not touch.

## Not done: the device install

`build_device` fails in the `OpenTaskWidgets` target before compiling anything:

```
Provisioning profile "iOS Team Provisioning Profile: *" doesn't include the App Groups capability
```

There is no provisioning profile for `io.mcnitt.opentask.widgets` in either profile directory on this Mac, and automatic signing cannot mint one: `-allowProvisioningUpdates` reports `Unable to log in with account 'misc_dev_work@pm.me'` — the Xcode account's portal session has expired. Retrying with the App Store Connect API key in `~/.creds/loam-asc.env` (same team, `GEL3VGTUJX`) returned `Authentication failed: ... bearer token ... has not expired`, so that key does not work for this either.

**To install:** re-authenticate in Xcode → Settings → Accounts, then `build_device` + `install_app_device` for `Trent's iPhone 16 Pro` (never launch it — installing preserves Keychain state, launching can force credential re-entry).

Once installed, opening the app is enough to refresh the widget: `OpenTaskApp.swift` calls `WidgetCenter.shared.reloadAllTimelines()` on `scenePhase == .active`. The order unfreezes on the first timeline pass whose payload actually carries anchors — a live fetch, not the stale cache — so the re-rank may land on the second pass rather than the first. No need to remove and re-add the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
