### PR TITLE
feat(reminders): a tap considers the thought, a hold selects it

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -160,6 +160,25 @@
   animation: fade-in 0.15s ease-out;
 }
 
+/* A deep-linked row (?reminder=<id>, the iOS widget's link): a short flash
+   that says "this one", then nothing. It runs once on the element it lands on
+   and is never cleared in state, so a re-render cannot make it flash again. */
+@keyframes row-highlight {
+  0%,
+  55% {
+    background-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--ring);
+  }
+  100% {
+    background-color: transparent;
+    box-shadow: 0 0 0 2px transparent;
+  }
+}
+
+.animate-row-highlight {
+  animation: row-highlight 2s ease-out;
+}
+
 /* Hide scrollbar for horizontal scroll areas */
 .scrollbar-hide::-webkit-scrollbar {
   display: none;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -160,6 +160,48 @@
   animation: fade-in 0.15s ease-out;
 }
 
+/* A considered reminder leaving its slot.
+   It holds its full height for the first half — long enough that the second
+   click of a double-click lands on the inert row it just struck through
+   rather than on whichever thought would otherwise have slid up into the gap
+   — and only then collapses. The row is removed from the list on this
+   animation's `animationend`, never on a timer, so the two can never disagree.
+   `--reminder-row-h` is measured on the element as the animation starts,
+   because a row's height is however long its thought is. */
+@keyframes reminder-leaving {
+  0% {
+    height: var(--reminder-row-h);
+    opacity: 1;
+  }
+  50% {
+    height: var(--reminder-row-h);
+    opacity: 0.45;
+  }
+  100% {
+    height: 0;
+    margin-top: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-top-width: 0;
+    border-bottom-width: 0;
+    opacity: 0;
+  }
+}
+
+.animate-reminder-leaving {
+  animation: reminder-leaving 180ms ease-out forwards;
+  overflow: hidden;
+}
+
+/* Reduced motion still needs the event — the row is removed by `animationend`,
+   so it must fire. A zero-duration animation does fire it, and the dev check
+   confirms it end to end. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-reminder-leaving {
+    animation-duration: 0s;
+  }
+}
+
 /* A deep-linked row (?reminder=<id>, the iOS widget's link): a short flash
    that says "this one", then nothing. It runs once on the element it lands on
    and is never cleared in state, so a re-render cannot make it flash again. */

--- a/src/components/RemindersView.tsx
+++ b/src/components/RemindersView.tsx
@@ -110,6 +110,28 @@ interface RemindersViewProps {
   searchQuery?: string
 }
 
+/**
+ * Everything a reminder row can ask the surface to do.
+ *
+ * One object rather than nine props, because the same set is threaded
+ * unchanged through the slot groups and the search view, and a chain that long
+ * drifts: it is how `onLeft` reached the rows in a slot before it reached the
+ * ones in a search result.
+ */
+interface ReminderRowHandlers {
+  onSelect: (task: Task) => void
+  onRangeSelect: (task: Task) => void
+  onOpen: (task: Task) => void
+  onComplete: (task: Task) => void
+  onRetry: (task: Task) => void
+  /** This row has finished collapsing and may leave the list. */
+  onLeft: (id: number) => void
+  /** The deep link's flash has played; it must not play again on a remount. */
+  onHighlightDone: () => void
+  /** Report that a row is on screen; returns its own deregistration. */
+  onRegister: (id: number) => () => void
+}
+
 /** Stable identity for a group across refetches — slot id, or the un-slotted bucket. */
 function groupKey(group: ReminderGroup): string {
   return group.slot ? String(group.slot.id) : 'unslotted'
@@ -137,6 +159,8 @@ export function RemindersView({
     completeMany,
     completeGroup,
     rowLeft,
+    registerRow,
+    hydrated,
     putBack,
     remove,
     refresh,
@@ -282,9 +306,19 @@ export function RemindersView({
    */
   const [highlightId, setHighlightId] = useState<number | null>(null)
   const [openNotToday, setOpenNotToday] = useState(false)
+  // Once the flash has played it is spent. Without this the row would flash —
+  // and drag the viewport back to itself — every time it remounted, which a
+  // fold, a search, or a slot re-render does minutes after the link was used.
+  const clearHighlight = useCallback(() => setHighlightId(null), [])
   const deepLinkDone = useRef(false)
   useEffect(() => {
-    if (deepLinkDone.current || loading || error) return
+    // `hydrated`, not `loading`: the module cache paints the surface instantly
+    // on a client-side visit, so `loading` is already false over data that may
+    // predate the reminder being linked to. Consuming the param then would
+    // spend it on a list that simply had not been fetched yet — the same trap
+    // the dashboard's `?task=` avoids by refusing to resolve against an empty
+    // list.
+    if (deepLinkDone.current || !hydrated || error) return
     // Read the URL directly rather than through useSearchParams: the param is
     // stripped below with a raw history rewrite (same reason as the dashboard's
     // — a router.replace issues an RSC fetch that can remount this surface),
@@ -314,7 +348,7 @@ export function RemindersView({
       scrolledRef.current = true
     }
     window.history.replaceState(window.history.state, '', window.location.pathname)
-  }, [loading, error, groups, notToday, setOpen, setExpanded])
+  }, [hydrated, error, groups, notToday, setOpen, setExpanded])
 
   // Land on the slot the day is actually in.
   //
@@ -535,6 +569,29 @@ export function RemindersView({
     [onUndo, onCompleted, refresh],
   )
 
+  const rowHandlers: ReminderRowHandlers = useMemo(
+    () => ({
+      onSelect: actions.selectRow,
+      onRangeSelect: actions.rangeSelectRow,
+      onOpen: openDetail,
+      onComplete: actions.complete,
+      onRetry: retryEnrichment,
+      onLeft: rowLeft,
+      onHighlightDone: clearHighlight,
+      onRegister: registerRow,
+    }),
+    [
+      actions.selectRow,
+      actions.rangeSelectRow,
+      openDetail,
+      actions.complete,
+      retryEnrichment,
+      rowLeft,
+      clearHighlight,
+      registerRow,
+    ],
+  )
+
   return (
     // Clearance below the last row for the floating selection bar, so the
     // end of the list can always be scrolled out from under it.
@@ -563,12 +620,7 @@ export function RemindersView({
           completingIds={completingIds}
           selectedIds={selectedIds}
           isSelectionMode={actions.isSelectionMode}
-          onSelect={actions.selectRow}
-          onRangeSelect={actions.rangeSelectRow}
-          onRowOpen={openDetail}
-          onComplete={actions.complete}
-          onRetry={retryEnrichment}
-          onLeft={rowLeft}
+          rowHandlers={rowHandlers}
           onPutBack={putBack}
         />
       ) : visibleGroups.length === 0 ? (
@@ -606,12 +658,7 @@ export function RemindersView({
                     selectedIds={selectedIds}
                     isSelectionMode={actions.isSelectionMode}
                     highlightId={highlightId}
-                    onSelect={actions.selectRow}
-                    onRangeSelect={actions.rangeSelectRow}
-                    onRowOpen={openDetail}
-                    onComplete={actions.complete}
-                    onRetry={retryEnrichment}
-                    onLeft={rowLeft}
+                    rowHandlers={rowHandlers}
                     onCompleteGroup={considerAll.askSlot}
                     onPutBack={putBack}
                   />
@@ -631,6 +678,7 @@ export function RemindersView({
           onOpen={openDetail}
           requestOpen={openNotToday}
           highlightId={highlightId}
+          onHighlightDone={clearHighlight}
         />
       )}
 
@@ -1005,12 +1053,7 @@ function ReminderSlotGroup({
   selectedIds,
   isSelectionMode,
   highlightId,
-  onSelect,
-  onRangeSelect,
-  onRowOpen,
-  onComplete,
-  onRetry,
-  onLeft,
+  rowHandlers,
   onCompleteGroup,
   onPutBack,
 }: {
@@ -1028,12 +1071,7 @@ function ReminderSlotGroup({
   selectedIds: Set<number>
   isSelectionMode: boolean
   highlightId: number | null
-  onSelect: (task: Task) => void
-  onRangeSelect: (task: Task) => void
-  onRowOpen: (task: Task) => void
-  onComplete: (task: Task) => void
-  onRetry: (task: Task) => void
-  onLeft: (id: number) => void
+  rowHandlers: ReminderRowHandlers
   onCompleteGroup: (group: ReminderGroup) => void
   onPutBack: (task: Task) => void
 }) {
@@ -1119,12 +1157,7 @@ function ReminderSlotGroup({
                   selected={selectedIds.has(reminder.id)}
                   isSelectionMode={isSelectionMode}
                   highlighted={highlightId === reminder.id}
-                  onSelect={onSelect}
-                  onRangeSelect={onRangeSelect}
-                  onOpen={onRowOpen}
-                  onComplete={onComplete}
-                  onRetry={onRetry}
-                  onLeft={onLeft}
+                  {...rowHandlers}
                 />
               ))}
             </ul>
@@ -1326,6 +1359,55 @@ const scrollRowIntoView = (el: HTMLElement | null) => {
 }
 
 /**
+ * A row's own classes.
+ *
+ * The load-bearing part is the animation. `animation` is ONE property and three
+ * of these set it, so they must never be on the row together: the last one
+ * defined in the stylesheet would win and the others would simply not run.
+ * That matters beyond looks — the leaving animation's `animationend` is what
+ * removes the row and releases the surface's held refresh, so an AI pulse
+ * quietly beating it would strand a struck-through row and switch refreshing
+ * off for the rest of the session. While a row is leaving, leaving is the only
+ * animation it gets.
+ */
+function reminderRowClasses({
+  completing,
+  selected,
+  highlighted,
+  aiProcessing,
+}: {
+  completing: boolean
+  selected: boolean
+  highlighted: boolean
+  aiProcessing: boolean
+}): string {
+  return cn(
+    // The border is always there, transparent, so the processing pulse has
+    // something to color without the row shifting by a pixel.
+    'group flex cursor-pointer items-start gap-3 rounded-xl border border-transparent px-2 py-2.5 select-none',
+    'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
+    selected ? 'ring-ring bg-accent ring-2' : 'hover:bg-foreground/[0.04]',
+    completing && 'animate-reminder-leaving pointer-events-none',
+    !completing && aiProcessing && 'animate-ai-processing',
+    !completing && highlighted && 'animate-row-highlight',
+  )
+}
+
+/**
+ * Move focus off a row that is about to be considered: the next row, else the
+ * one before it, else the slot's own header. Keyboard work down a slot should
+ * carry on where it was, and focus must never end up on <body>.
+ */
+function focusAfterRow(row: HTMLElement): void {
+  const next = row.nextElementSibling as HTMLElement | null
+  const prev = row.previousElementSibling as HTMLElement | null
+  const header = row
+    .closest('[data-slot-group]')
+    ?.querySelector<HTMLElement>('button[aria-expanded]')
+  ;(next ?? prev ?? header)?.focus()
+}
+
+/**
  * Hand the leaving animation the height it has to collapse from.
  *
  * A callback ref rather than an effect: React attaches refs during the commit,
@@ -1356,18 +1438,27 @@ const measureLeavingRow = (el: HTMLElement | null) => {
  */
 function useReminderRowGestures({
   reminder,
+  completing,
+  highlighted,
   isSelectionMode,
   onComplete,
   onSelect,
   onRangeSelect,
   onOpen,
+  onLeft,
+  onHighlightDone,
 }: {
   reminder: Task
+  /** Already considered and on its way out — every gesture is a no-op. */
+  completing: boolean
+  highlighted: boolean
   isSelectionMode: boolean
   onComplete: (task: Task) => void
   onSelect: (task: Task) => void
   onRangeSelect: (task: Task) => void
   onOpen: (task: Task) => void
+  onLeft: (id: number) => void
+  onHighlightDone: () => void
 }) {
   // In selection mode the hold extends the range from the anchor, exactly as on
   // the dashboard; out of it, the hold is what turns selection mode on.
@@ -1386,6 +1477,9 @@ function useReminderRowGestures({
       }
       // The circle, the checkbox and Retry own their own clicks.
       if (fromRowControl(e)) return
+      // A row on its way out is inert to pointers in CSS as well; this is the
+      // same answer for anything that gets past that.
+      if (completing) return
       // A held modifier never completes: it is the mouse's fast way into a
       // selection, and a slip that considered a thought is the one mistake
       // this surface should not make.
@@ -1393,7 +1487,7 @@ function useReminderRowGestures({
       else if (e.metaKey || e.ctrlKey || isSelectionMode) onSelect(reminder)
       else onComplete(reminder)
     },
-    [pointer, isSelectionMode, onComplete, onSelect, onRangeSelect, reminder],
+    [pointer, completing, isSelectionMode, onComplete, onSelect, onRangeSelect, reminder],
   )
 
   /**
@@ -1406,6 +1500,11 @@ function useReminderRowGestures({
       // Enter on the circle or on Retry has already done its work; the same
       // keystroke bubbles here and must not do it a second time.
       if (e.target !== e.currentTarget) return
+      // Focus stays on a row while it collapses (the browser does not move it
+      // just because tabindex went to -1), so a second Enter inside those
+      // 180ms would ask for a second completion — and a recurring reminder
+      // would advance two occurrences for one intention.
+      if (completing) return
       if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()
         onOpen(reminder)
@@ -1413,13 +1512,37 @@ function useReminderRowGestures({
       }
       if (e.key !== 'Enter' && e.key !== ' ') return
       e.preventDefault()
-      if (isSelectionMode) onSelect(reminder)
-      else onComplete(reminder)
+      if (isSelectionMode) {
+        onSelect(reminder)
+        return
+      }
+      // Hand focus on before the row goes, or it falls to <body> and the next
+      // Tab starts again from the top of the page.
+      focusAfterRow(e.currentTarget as HTMLElement)
+      onComplete(reminder)
     },
-    [isSelectionMode, onComplete, onSelect, onOpen, reminder],
+    [completing, isSelectionMode, onComplete, onSelect, onOpen, reminder],
   )
 
-  return { pointer, onClick, onKeyDown }
+  /**
+   * What an animation ending on this row MEANS. The list closes the gap only
+   * once the row has visibly gone, and the deep link's flash is spent once it
+   * has played; both arrive here, so the name is checked rather than assumed.
+   */
+  const onAnimationEnd = useCallback(
+    (e: React.AnimationEvent) => {
+      if (e.target !== e.currentTarget) return
+      if (e.animationName === 'reminder-leaving') {
+        if (highlighted) onHighlightDone()
+        onLeft(reminder.id)
+      } else if (e.animationName === 'row-highlight') {
+        onHighlightDone()
+      }
+    },
+    [highlighted, onHighlightDone, onLeft, reminder.id],
+  )
+
+  return { pointer, onClick, onKeyDown, onAnimationEnd }
 }
 
 /**
@@ -1505,6 +1628,8 @@ function ReminderRow({
   onComplete,
   onRetry,
   onLeft,
+  onHighlightDone,
+  onRegister,
 }: {
   reminder: Task
   completing: boolean
@@ -1519,6 +1644,10 @@ function ReminderRow({
   onRetry: (task: Task) => void
   /** This row has finished collapsing and may leave the list. */
   onLeft: (id: number) => void
+  /** The deep link's flash has played; it must not play again on a remount. */
+  onHighlightDone: () => void
+  /** Report that this row is on screen; returns its own deregistration. */
+  onRegister: (id: number) => () => void
 }) {
   const hasNotes = !!reminder.notes?.trim()
   const mark = cadenceMark(reminder.rrule)
@@ -1531,13 +1660,17 @@ function ReminderRow({
   const aiProcessing = reminder.labels.includes('ai-to-process')
   const aiFailed = reminder.labels.includes('ai-failed')
 
-  const { pointer, onClick, onKeyDown } = useReminderRowGestures({
+  const { pointer, onClick, onKeyDown, onAnimationEnd } = useReminderRowGestures({
     reminder,
+    completing,
+    highlighted,
     isSelectionMode,
     onComplete,
     onSelect,
     onRangeSelect,
     onOpen,
+    onLeft,
+    onHighlightDone,
   })
 
   // The animation is what normally releases the row, but a row can be taken
@@ -1549,6 +1682,13 @@ function ReminderRow({
     if (!completing) return
     return () => onLeft(id)
   }, [completing, onLeft, id])
+
+  // Being on screen is what qualifies a row to hold its place when it is
+  // considered — and to hold the surface's refresh with it. A row that is not
+  // rendered (a folded slot, or under a "Show all N" cap) cannot report its
+  // animation finishing, so the surface must know which rows these are rather
+  // than assume every completed id has one. See `completeIds`.
+  useEffect(() => onRegister(id), [onRegister, id])
 
   return (
     <li
@@ -1572,22 +1712,8 @@ function ReminderRow({
       onPointerMove={pointer.onPointerMove}
       onPointerLeave={pointer.onPointerLeave}
       onPointerCancel={pointer.onPointerUp}
-      // The list closes the gap only once the row has visibly gone. Other
-      // animations end on this element too (the deep-link flash), so the name
-      // is checked rather than assumed.
-      onAnimationEnd={(e) => {
-        if (e.target === e.currentTarget && e.animationName === 'reminder-leaving') onLeft(id)
-      }}
-      className={cn(
-        // The border is always there, transparent, so the processing pulse has
-        // something to color without the row shifting by a pixel.
-        'group flex cursor-pointer items-start gap-3 rounded-xl border border-transparent px-2 py-2.5 select-none',
-        'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
-        selected ? 'ring-ring bg-accent ring-2' : 'hover:bg-foreground/[0.04]',
-        completing && 'animate-reminder-leaving pointer-events-none',
-        aiProcessing && 'animate-ai-processing',
-        highlighted && 'animate-row-highlight',
-      )}
+      onAnimationEnd={onAnimationEnd}
+      className={reminderRowClasses({ completing, selected, highlighted, aiProcessing })}
       data-ai-state={aiProcessing ? 'processing' : aiFailed ? 'failed' : undefined}
     >
       <ReminderRowMarker
@@ -1665,12 +1791,7 @@ function SearchResults({
   completingIds,
   selectedIds,
   isSelectionMode,
-  onSelect,
-  onRangeSelect,
-  onRowOpen,
-  onComplete,
-  onRetry,
-  onLeft,
+  rowHandlers,
   onPutBack,
 }: {
   count: number
@@ -1680,12 +1801,7 @@ function SearchResults({
   completingIds: Set<number>
   selectedIds: Set<number>
   isSelectionMode: boolean
-  onSelect: (task: Task) => void
-  onRangeSelect: (task: Task) => void
-  onRowOpen: (task: Task) => void
-  onComplete: (task: Task) => void
-  onRetry: (task: Task) => void
-  onLeft: (id: number) => void
+  rowHandlers: ReminderRowHandlers
   onPutBack: (task: Task) => void
 }) {
   return (
@@ -1713,17 +1829,14 @@ function SearchResults({
               selectedIds={selectedIds}
               isSelectionMode={isSelectionMode}
               highlightId={null}
-              onSelect={onSelect}
-              onRangeSelect={onRangeSelect}
-              onRowOpen={onRowOpen}
-              onComplete={onComplete}
-              onRetry={onRetry}
-              onLeft={onLeft}
+              rowHandlers={rowHandlers}
               onCompleteGroup={NO_OP}
               onPutBack={onPutBack}
             />
           ))}
-          {notToday.length > 0 && <NotTodayFold items={notToday} onOpen={onRowOpen} forceOpen />}
+          {notToday.length > 0 && (
+            <NotTodayFold items={notToday} onOpen={rowHandlers.onOpen} forceOpen />
+          )}
         </div>
       )}
     </>
@@ -1746,6 +1859,7 @@ function NotTodayFold({
   forceOpen = false,
   requestOpen = false,
   highlightId = null,
+  onHighlightDone = NO_OP,
 }: {
   items: Task[]
   onOpen: (task: Task) => void
@@ -1759,6 +1873,8 @@ function NotTodayFold({
   requestOpen?: boolean
   /** The deep-linked row: scrolled to and flashed, as in a slot. */
   highlightId?: number | null
+  /** The flash has played and must not play again on a remount. */
+  onHighlightDone?: () => void
 }) {
   // `requestOpen` moves the DEFAULT rather than forcing the fold: a deep link
   // opens it, and the moment the user touches the caret their answer (null
@@ -1795,6 +1911,11 @@ function NotTodayFold({
                 data-not-today-id={task.id}
                 data-reminder-highlight={highlighted ? '' : undefined}
                 ref={highlighted ? scrollRowIntoView : undefined}
+                onAnimationEnd={(e) => {
+                  if (e.target === e.currentTarget && e.animationName === 'row-highlight') {
+                    onHighlightDone()
+                  }
+                }}
                 className={cn('rounded-xl', highlighted && 'animate-row-highlight')}
               >
                 <button

--- a/src/components/RemindersView.tsx
+++ b/src/components/RemindersView.tsx
@@ -136,6 +136,7 @@ export function RemindersView({
     complete,
     completeMany,
     completeGroup,
+    rowLeft,
     putBack,
     remove,
     refresh,
@@ -567,6 +568,7 @@ export function RemindersView({
           onRowOpen={openDetail}
           onComplete={actions.complete}
           onRetry={retryEnrichment}
+          onLeft={rowLeft}
           onPutBack={putBack}
         />
       ) : visibleGroups.length === 0 ? (
@@ -609,6 +611,7 @@ export function RemindersView({
                     onRowOpen={openDetail}
                     onComplete={actions.complete}
                     onRetry={retryEnrichment}
+                    onLeft={rowLeft}
                     onCompleteGroup={considerAll.askSlot}
                     onPutBack={putBack}
                   />
@@ -1007,6 +1010,7 @@ function ReminderSlotGroup({
   onRowOpen,
   onComplete,
   onRetry,
+  onLeft,
   onCompleteGroup,
   onPutBack,
 }: {
@@ -1029,6 +1033,7 @@ function ReminderSlotGroup({
   onRowOpen: (task: Task) => void
   onComplete: (task: Task) => void
   onRetry: (task: Task) => void
+  onLeft: (id: number) => void
   onCompleteGroup: (group: ReminderGroup) => void
   onPutBack: (task: Task) => void
 }) {
@@ -1119,6 +1124,7 @@ function ReminderSlotGroup({
                   onOpen={onRowOpen}
                   onComplete={onComplete}
                   onRetry={onRetry}
+                  onLeft={onLeft}
                 />
               ))}
             </ul>
@@ -1320,6 +1326,18 @@ const scrollRowIntoView = (el: HTMLElement | null) => {
 }
 
 /**
+ * Hand the leaving animation the height it has to collapse from.
+ *
+ * A callback ref rather than an effect: React attaches refs during the commit,
+ * before the browser paints, so the row is measured at full size and the first
+ * painted frame of the animation already has the value. An effect would run
+ * after paint and leave one frame at `height: auto`.
+ */
+const measureLeavingRow = (el: HTMLElement | null) => {
+  if (el) el.style.setProperty('--reminder-row-h', `${el.offsetHeight}px`)
+}
+
+/**
  * A row's gestures (Trent, 2026-09-11): "I should be able to just tap reminders
  * pretty much anywhere to mark them done. I can press and hold any item to turn
  * on select mode, a little bit like the way tasks are set up… If you want to
@@ -1404,6 +1422,77 @@ function useReminderRowGestures({
   return { pointer, onClick, onKeyDown }
 }
 
+/**
+ * The 24px mark at the head of a row, in its three states.
+ *
+ * Leaving: a filled check, aria-hidden — it is the answer to the tap, not
+ * something still to press. Selection mode: a check box, as the dashboard's
+ * done button becomes. Otherwise: the circle, which considers this one item
+ * and never touches the selection, so it stops the row's click from reaching
+ * the row handler — and its pointer events too, or holding it would turn
+ * selection mode on underneath and swap the button out mid-press.
+ */
+function ReminderRowMarker({
+  reminder,
+  completing,
+  selected,
+  isSelectionMode,
+  onSelect,
+  onComplete,
+}: {
+  reminder: Task
+  completing: boolean
+  selected: boolean
+  isSelectionMode: boolean
+  onSelect: (task: Task) => void
+  onComplete: (task: Task) => void
+}) {
+  if (completing) {
+    return (
+      <span
+        aria-hidden
+        className="mt-[3px] flex size-6 shrink-0 items-center justify-center rounded-full bg-green-600 text-white"
+      >
+        <Check className="size-3.5" strokeWidth={3} />
+      </span>
+    )
+  }
+  if (isSelectionMode) {
+    return (
+      <Checkbox
+        checked={selected}
+        onCheckedChange={() => onSelect(reminder)}
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+        aria-label={`Select "${reminder.title}"`}
+        className="mt-[3px] size-6 shrink-0"
+      />
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        onComplete(reminder)
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      // The row itself is the tab stop and Enter/Space on it does exactly what
+      // this button does, so a second stop per row would be pure duplication on
+      // a surface that can hold seventy of them.
+      tabIndex={-1}
+      aria-label={`Mark "${reminder.title}" as considered`}
+      title="Considered"
+      className="border-foreground/20 hover:border-foreground/60 hover:bg-foreground/5 mt-[3px] flex size-6 shrink-0 items-center justify-center rounded-full border-[1.5px] transition-colors"
+    >
+      <Check
+        className="group-hover:text-foreground/40 size-3.5 text-transparent transition-colors"
+        strokeWidth={3}
+      />
+    </button>
+  )
+}
+
 function ReminderRow({
   reminder,
   completing,
@@ -1415,6 +1504,7 @@ function ReminderRow({
   onOpen,
   onComplete,
   onRetry,
+  onLeft,
 }: {
   reminder: Task
   completing: boolean
@@ -1427,6 +1517,8 @@ function ReminderRow({
   onOpen: (task: Task) => void
   onComplete: (task: Task) => void
   onRetry: (task: Task) => void
+  /** This row has finished collapsing and may leave the list. */
+  onLeft: (id: number) => void
 }) {
   const hasNotes = !!reminder.notes?.trim()
   const mark = cadenceMark(reminder.rrule)
@@ -1448,16 +1540,31 @@ function ReminderRow({
     onOpen,
   })
 
+  // The animation is what normally releases the row, but a row can be taken
+  // off screen before it ends — a slot folded, the surface navigated away
+  // from. Reporting it on unmount too means a considered thought can never be
+  // left half-gone, and can never hold the surface's refresh shut.
+  const id = reminder.id
+  useEffect(() => {
+    if (!completing) return
+    return () => onLeft(id)
+  }, [completing, onLeft, id])
+
   return (
     <li
       data-reminder-id={reminder.id}
       data-reminder-highlight={highlighted ? '' : undefined}
-      ref={highlighted ? scrollRowIntoView : undefined}
+      data-reminder-leaving={completing ? '' : undefined}
+      ref={completing ? measureLeavingRow : highlighted ? scrollRowIntoView : undefined}
       role="option"
       aria-selected={selected}
+      // Struck through, inert, and out of the tab order the moment it is
+      // considered: what is on screen is a record of what just happened, not
+      // something still to act on.
+      aria-disabled={completing || undefined}
       // The row is the keyboard's way in — it has to be focusable for
       // Enter/Space to reach it at all, and it is what a screen reader reads.
-      tabIndex={0}
+      tabIndex={completing ? -1 : 0}
       onClick={onClick}
       onKeyDown={onKeyDown}
       onPointerDown={pointer.onPointerDown}
@@ -1465,57 +1572,42 @@ function ReminderRow({
       onPointerMove={pointer.onPointerMove}
       onPointerLeave={pointer.onPointerLeave}
       onPointerCancel={pointer.onPointerUp}
+      // The list closes the gap only once the row has visibly gone. Other
+      // animations end on this element too (the deep-link flash), so the name
+      // is checked rather than assumed.
+      onAnimationEnd={(e) => {
+        if (e.target === e.currentTarget && e.animationName === 'reminder-leaving') onLeft(id)
+      }}
       className={cn(
         // The border is always there, transparent, so the processing pulse has
         // something to color without the row shifting by a pixel.
-        'group flex cursor-pointer items-start gap-3 rounded-xl border border-transparent px-2 py-2.5 transition-all duration-200 ease-out select-none',
+        'group flex cursor-pointer items-start gap-3 rounded-xl border border-transparent px-2 py-2.5 select-none',
         'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
         selected ? 'ring-ring bg-accent ring-2' : 'hover:bg-foreground/[0.04]',
-        completing && 'pointer-events-none translate-x-2 opacity-0',
+        completing && 'animate-reminder-leaving pointer-events-none',
         aiProcessing && 'animate-ai-processing',
         highlighted && 'animate-row-highlight',
       )}
       data-ai-state={aiProcessing ? 'processing' : aiFailed ? 'failed' : undefined}
     >
-      {/* In selection mode the circle becomes a check mark, as the dashboard's
-          done button does — the row's tap is a selection then, and a circle
-          still offering to complete would contradict it. */}
-      {isSelectionMode ? (
-        <Checkbox
-          checked={selected}
-          onCheckedChange={() => onSelect(reminder)}
-          onClick={(e) => e.stopPropagation()}
-          onPointerDown={(e) => e.stopPropagation()}
-          aria-label={`Select "${reminder.title}"`}
-          className="mt-[3px] size-6 shrink-0"
-        />
-      ) : (
-        /* The circle considers this one item directly and never touches the
-           selection, so it stops the row's click from reaching the handler —
-           and its pointer events too, or holding it would turn selection mode
-           on underneath and swap the button out mid-press. */
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            onComplete(reminder)
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-          aria-label={`Mark "${reminder.title}" as considered`}
-          title="Considered"
-          className="border-foreground/20 hover:border-foreground/60 hover:bg-foreground/5 mt-[3px] flex size-6 shrink-0 items-center justify-center rounded-full border-[1.5px] transition-colors"
-        >
-          <Check
-            className="group-hover:text-foreground/40 size-3.5 text-transparent transition-colors"
-            strokeWidth={3}
-          />
-        </button>
-      )}
+      <ReminderRowMarker
+        reminder={reminder}
+        completing={completing}
+        selected={selected}
+        isSelectionMode={isSelectionMode}
+        onSelect={onSelect}
+        onComplete={onComplete}
+      />
       {/* The notes marker sits inline after the title rather than pinned to
           the right edge: on a wide screen a lone icon across the row reads as
           an unrelated control, and this one is only ever a footnote. */}
-      <p className="min-w-0 flex-1 text-[16px] leading-6">
-        <span className={cn('text-pretty', prominenceClasses(reminder.priority))}>
+      <p className={cn('min-w-0 flex-1 text-[16px] leading-6', completing && 'line-through')}>
+        <span
+          className={cn(
+            'text-pretty',
+            completing ? 'text-muted-foreground' : prominenceClasses(reminder.priority),
+          )}
+        >
           {reminder.title}
         </span>
         {/* Not every day: the day codes, "Monthly", "Once". Daily wears nothing. */}
@@ -1578,6 +1670,7 @@ function SearchResults({
   onRowOpen,
   onComplete,
   onRetry,
+  onLeft,
   onPutBack,
 }: {
   count: number
@@ -1592,6 +1685,7 @@ function SearchResults({
   onRowOpen: (task: Task) => void
   onComplete: (task: Task) => void
   onRetry: (task: Task) => void
+  onLeft: (id: number) => void
   onPutBack: (task: Task) => void
 }) {
   return (
@@ -1624,6 +1718,7 @@ function SearchResults({
               onRowOpen={onRowOpen}
               onComplete={onComplete}
               onRetry={onRetry}
+              onLeft={onLeft}
               onCompleteGroup={NO_OP}
               onPutBack={onPutBack}
             />

--- a/src/components/RemindersView.tsx
+++ b/src/components/RemindersView.tsx
@@ -10,11 +10,13 @@ import { summarizeReminders, type RemindersSummary } from '@/lib/reminders-summa
 import { cadenceMark, slotAtMinutes } from '@/lib/reminder-rule'
 import { saveTaskChanges } from '@/lib/save-task-changes'
 import { showToast } from '@/lib/toast'
+import { useLongPress } from '@/hooks/useLongPress'
 import { useReminders, type ReminderCreateInput, type ReminderGroup } from '@/hooks/useReminders'
 import { useSelectionMode } from '@/hooks/useSelectionMode'
 import { useTimeSlots } from '@/hooks/useTimeSlots'
 import { useTimezone } from '@/hooks/useTimezone'
 import { useSyncStream } from '@/hooks/useSyncStream'
+import { Checkbox } from '@/components/ui/checkbox'
 import { ReminderSelectionBar } from '@/components/ReminderSelectionBar'
 import { ReminderDetailModal } from '@/components/ReminderDetailModal'
 import { QuickAdd } from '@/components/QuickAdd'
@@ -50,9 +52,14 @@ import type { Task } from '@/types'
  *    through all the reminders"). It only ever counts what he did — a bar that
  *    filled with misses would read intent from absence (L1).
  *
- * Selection works exactly as it does on the dashboard, on purpose: plain click
- * selects, shift-click a range, cmd/ctrl-click adds, Escape clears; the same
- * floating bar appears with the verbs that apply. A row click never navigates.
+ * Touching a row considers it (Trent, 2026-09-11: "I should be able to just
+ * tap reminders pretty much anywhere to mark them done"). Selection is behind a
+ * press-and-hold, the same 400ms gesture the dashboard's TaskRow uses, and the
+ * same floating bar appears with the verbs that apply — including Details,
+ * which is now the deliberate way in to a reminder's editor ("we just tap and
+ * hold and then click Details with the item checked"). A mouse keeps its
+ * shortcuts into a selection: shift-click a range, cmd/ctrl-click to add.
+ * Escape clears. A row click never navigates.
  *
  * Completed items leave immediately, and a slot that never had anything today
  * is not shown (on this surface there is no day to read, only thoughts still
@@ -252,7 +259,61 @@ export function RemindersView({
     return withWaiting.length > 0 ? groupKey(withWaiting[0]) : null
   }, [visibleGroups, timezone])
 
-  const { isOpen, toggleOpen, expandedKeys, setExpanded } = useSlotDisclosure()
+  const { isOpen, toggleOpen, expandedKeys, setOpen, setExpanded } = useSlotDisclosure()
+
+  // Claimed by whichever of the two effects below gets to it first: a deep
+  // link is a place the user asked for, and it outranks the current slot.
+  const scrolledRef = useRef(false)
+
+  /**
+   * `?reminder=<id>` — the deep link the iOS widget opens.
+   *
+   * The row is brought on screen and flashed once; nothing is opened. The
+   * widget's user tapped a thought to SEE it, and an editor over the top of the
+   * surface would hide the five thoughts around it that are the reason they
+   * looked. (The dashboard's `?task=` does open its panel — a task tapped from
+   * a notification is one thing to act on, not a place in a list.)
+   *
+   * The id is looked up once the fetch has resolved. Found or not, that answer
+   * is definitive — unlike the dashboard's list, an empty payload here is a
+   * real "no reminders" — so the param is consumed either way. An error is the
+   * one case that waits: a retry may still find it.
+   */
+  const [highlightId, setHighlightId] = useState<number | null>(null)
+  const [openNotToday, setOpenNotToday] = useState(false)
+  const deepLinkDone = useRef(false)
+  useEffect(() => {
+    if (deepLinkDone.current || loading || error) return
+    // Read the URL directly rather than through useSearchParams: the param is
+    // stripped below with a raw history rewrite (same reason as the dashboard's
+    // — a router.replace issues an RSC fetch that can remount this surface),
+    // which the hook does not observe anyway, and reading window.location keeps
+    // this component out of a Suspense boundary it otherwise would need.
+    const raw = new URLSearchParams(window.location.search).get('reminder')
+    if (!raw) {
+      deepLinkDone.current = true
+      return
+    }
+    deepLinkDone.current = true
+    const id = Number.parseInt(raw, 10)
+    const group = Number.isNaN(id)
+      ? undefined
+      : groups.find((g) => g.reminders.some((r) => r.id === id))
+    if (group) {
+      // A slot the user folded, or one still ahead in the day showing only its
+      // first few, would leave the linked row unrendered. Open and uncap it.
+      const key = groupKey(group)
+      setOpen(key, true)
+      setExpanded(key, true)
+      setHighlightId(id)
+      scrolledRef.current = true
+    } else if (!Number.isNaN(id) && notToday.some((t) => t.id === id)) {
+      setOpenNotToday(true)
+      setHighlightId(id)
+      scrolledRef.current = true
+    }
+    window.history.replaceState(window.history.state, '', window.location.pathname)
+  }, [loading, error, groups, notToday, setOpen, setExpanded])
 
   // Land on the slot the day is actually in.
   //
@@ -263,7 +324,6 @@ export function RemindersView({
   //
   // Once per load, never during a search (the results are the subject then),
   // and never if the current slot is already the first thing on screen.
-  const scrolledRef = useRef(false)
   useEffect(() => {
     if (searching || scrolledRef.current || !currentKey) return
     const el = document.querySelector(`[data-slot-key="${CSS.escape(currentKey)}"]`)
@@ -501,7 +561,9 @@ export function RemindersView({
           notToday={searchNotToday}
           completingIds={completingIds}
           selectedIds={selectedIds}
-          onRowClick={actions.rowClick}
+          isSelectionMode={actions.isSelectionMode}
+          onSelect={actions.selectRow}
+          onRangeSelect={actions.rangeSelectRow}
           onRowOpen={openDetail}
           onComplete={actions.complete}
           onRetry={retryEnrichment}
@@ -540,7 +602,10 @@ export function RemindersView({
                     onExpand={(expanded) => setExpanded(key, expanded)}
                     completingIds={completingIds}
                     selectedIds={selectedIds}
-                    onRowClick={actions.rowClick}
+                    isSelectionMode={actions.isSelectionMode}
+                    highlightId={highlightId}
+                    onSelect={actions.selectRow}
+                    onRangeSelect={actions.rangeSelectRow}
                     onRowOpen={openDetail}
                     onComplete={actions.complete}
                     onRetry={retryEnrichment}
@@ -557,7 +622,14 @@ export function RemindersView({
       {/* Reminders with no occurrence today, so a weekly thought is reachable
           on its off days (Trent, 2026-09-05). Never counted; a row opens its
           editor, since there is nothing to consider today. */}
-      {!loading && notToday.length > 0 && <NotTodayFold items={notToday} onOpen={openDetail} />}
+      {!loading && notToday.length > 0 && (
+        <NotTodayFold
+          items={notToday}
+          onOpen={openDetail}
+          requestOpen={openNotToday}
+          highlightId={highlightId}
+        />
+      )}
 
       <ReminderSelectionBar
         selectedCount={selectedIds.size}
@@ -612,7 +684,7 @@ function useReminderActions({
   completeGroup: (group: ReminderGroup) => Promise<void>
   remove: (tasks: Task[]) => Promise<void>
 }) {
-  const { isSelectionMode, toggle, rangeSelect, selectOnly, removeAll, clear } = selection
+  const { isSelectionMode, toggle, rangeSelect, removeAll, clear } = selection
 
   useEffect(() => {
     if (!isSelectionMode) return
@@ -623,13 +695,17 @@ function useReminderActions({
     return () => window.removeEventListener('keydown', onKey)
   }, [isSelectionMode, clear])
 
-  const rowClick = useCallback(
-    (task: Task, e: React.MouseEvent) => {
-      if (e.shiftKey) rangeSelect(task.id, orderedIds)
-      else if (e.metaKey || e.ctrlKey) toggle(task.id)
-      else selectOnly(task.id)
-    },
-    [rangeSelect, toggle, selectOnly, orderedIds],
+  /**
+   * Add or remove one row. Deliberately `toggle`, where the dashboard's plain
+   * desktop click is `selectOnly`: there, a click that replaced the selection
+   * costs a click to undo, but here dropping out of selection mode means the
+   * NEXT tap considers the thought. Replace-and-exit is a footgun this surface
+   * has and the dashboard does not, so every tap in selection mode accumulates.
+   */
+  const selectRow = useCallback((task: Task) => toggle(task.id), [toggle])
+  const rangeSelectRow = useCallback(
+    (task: Task) => rangeSelect(task.id, orderedIds),
+    [rangeSelect, orderedIds],
   )
   const completeOne = useCallback(
     (task: Task) => {
@@ -678,7 +754,9 @@ function useReminderActions({
   )
 
   return {
-    rowClick,
+    isSelectionMode,
+    selectRow,
+    rangeSelectRow,
     complete: completeOne,
     completeGroup: completeSlot,
     considerSelection,
@@ -851,15 +929,26 @@ function useSlotDisclosure() {
     },
     [isOpen],
   )
+  // Both setters return the previous state untouched when nothing would
+  // change. The deep-link effect below asks for a slot to be open and expanded
+  // while reading `expandedKeys`; a fresh Set every call would re-render, re-run
+  // the effect, and ask again forever.
+  const setOpen = useCallback((key: string, open: boolean) => {
+    setOpenOverrides((prev) => {
+      if ((prev.get(key) ?? true) === open) return prev
+      return new Map(prev).set(key, open)
+    })
+  }, [])
   const setExpanded = useCallback((key: string, expanded: boolean) => {
     setExpandedKeys((prev) => {
+      if (prev.has(key) === expanded) return prev
       const next = new Set(prev)
       if (expanded) next.add(key)
       else next.delete(key)
       return next
     })
   }, [])
-  return { isOpen, toggleOpen, expandedKeys, setExpanded }
+  return { isOpen, toggleOpen, expandedKeys, setOpen, setExpanded }
 }
 
 /**
@@ -911,7 +1000,10 @@ function ReminderSlotGroup({
   onExpand,
   completingIds,
   selectedIds,
-  onRowClick,
+  isSelectionMode,
+  highlightId,
+  onSelect,
+  onRangeSelect,
   onRowOpen,
   onComplete,
   onRetry,
@@ -930,7 +1022,10 @@ function ReminderSlotGroup({
   onExpand: (expanded: boolean) => void
   completingIds: Set<number>
   selectedIds: Set<number>
-  onRowClick: (task: Task, e: React.MouseEvent) => void
+  isSelectionMode: boolean
+  highlightId: number | null
+  onSelect: (task: Task) => void
+  onRangeSelect: (task: Task) => void
   onRowOpen: (task: Task) => void
   onComplete: (task: Task) => void
   onRetry: (task: Task) => void
@@ -1017,7 +1112,10 @@ function ReminderSlotGroup({
                   reminder={reminder}
                   completing={completingIds.has(reminder.id)}
                   selected={selectedIds.has(reminder.id)}
-                  onClick={onRowClick}
+                  isSelectionMode={isSelectionMode}
+                  highlighted={highlightId === reminder.id}
+                  onSelect={onSelect}
+                  onRangeSelect={onRangeSelect}
                   onOpen={onRowOpen}
                   onComplete={onComplete}
                   onRetry={onRetry}
@@ -1208,11 +1306,112 @@ function ConsideredDisclosure({
   )
 }
 
+/**
+ * Bring a deep-linked row on screen (`?reminder=<id>`).
+ *
+ * A callback ref rather than an effect: the row may mount already highlighted
+ * (inside the "Not today" fold, which the link opens) or become highlighted
+ * while it is mounted, and React hands the node to a changed callback ref in
+ * both cases — one code path instead of two. Module-level so its identity is
+ * stable and it fires once.
+ */
+const scrollRowIntoView = (el: HTMLElement | null) => {
+  el?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+}
+
+/**
+ * A row's gestures (Trent, 2026-09-11): "I should be able to just tap reminders
+ * pretty much anywhere to mark them done. I can press and hold any item to turn
+ * on select mode, a little bit like the way tasks are set up… If you want to
+ * actually get the details, I guess we just tap and hold and then click Details
+ * with the item checked."
+ *
+ * So a tap considers, a hold selects, and details are one step further in. The
+ * hold is the dashboard's own `useLongPress` at the same 400ms with the same
+ * jitter tolerance; `didFire()` swallows the click the browser synthesises
+ * afterwards, without which every hold would also consider the thought it had
+ * just selected.
+ *
+ * It lives in a hook because the row is already near ESLint's function-length
+ * limit, and because the two halves — what a pointer means and what a key
+ * means — read better side by side than buried in the markup.
+ */
+function useReminderRowGestures({
+  reminder,
+  isSelectionMode,
+  onComplete,
+  onSelect,
+  onRangeSelect,
+  onOpen,
+}: {
+  reminder: Task
+  isSelectionMode: boolean
+  onComplete: (task: Task) => void
+  onSelect: (task: Task) => void
+  onRangeSelect: (task: Task) => void
+  onOpen: (task: Task) => void
+}) {
+  // In selection mode the hold extends the range from the anchor, exactly as on
+  // the dashboard; out of it, the hold is what turns selection mode on.
+  const onLongPress = useCallback(() => {
+    if (isSelectionMode) onRangeSelect(reminder)
+    else onSelect(reminder)
+  }, [isSelectionMode, onRangeSelect, onSelect, reminder])
+  const pointer = useLongPress({ onLongPress })
+
+  const onClick = useCallback(
+    (e: React.MouseEvent) => {
+      // The hold already acted; swallow the click it left behind.
+      if (pointer.didFire()) {
+        e.preventDefault()
+        return
+      }
+      // The circle, the checkbox and Retry own their own clicks.
+      if (fromRowControl(e)) return
+      // A held modifier never completes: it is the mouse's fast way into a
+      // selection, and a slip that considered a thought is the one mistake
+      // this surface should not make.
+      if (e.shiftKey) onRangeSelect(reminder)
+      else if (e.metaKey || e.ctrlKey || isSelectionMode) onSelect(reminder)
+      else onComplete(reminder)
+    },
+    [pointer, isSelectionMode, onComplete, onSelect, onRangeSelect, reminder],
+  )
+
+  /**
+   * Keyboard: the row is the tab stop, Enter/Space is the tap (considered, or
+   * the checkbox once selection mode is on), and Cmd/Ctrl+Enter opens details —
+   * the one thing hold-then-Details cannot offer a keyboard.
+   */
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // Enter on the circle or on Retry has already done its work; the same
+      // keystroke bubbles here and must not do it a second time.
+      if (e.target !== e.currentTarget) return
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        onOpen(reminder)
+        return
+      }
+      if (e.key !== 'Enter' && e.key !== ' ') return
+      e.preventDefault()
+      if (isSelectionMode) onSelect(reminder)
+      else onComplete(reminder)
+    },
+    [isSelectionMode, onComplete, onSelect, onOpen, reminder],
+  )
+
+  return { pointer, onClick, onKeyDown }
+}
+
 function ReminderRow({
   reminder,
   completing,
   selected,
-  onClick,
+  isSelectionMode,
+  highlighted,
+  onSelect,
+  onRangeSelect,
   onOpen,
   onComplete,
   onRetry,
@@ -1220,7 +1419,11 @@ function ReminderRow({
   reminder: Task
   completing: boolean
   selected: boolean
-  onClick: (task: Task, e: React.MouseEvent) => void
+  isSelectionMode: boolean
+  /** Deep-linked from the widget: scroll to it and flash it once. */
+  highlighted: boolean
+  onSelect: (task: Task) => void
+  onRangeSelect: (task: Task) => void
   onOpen: (task: Task) => void
   onComplete: (task: Task) => void
   onRetry: (task: Task) => void
@@ -1236,51 +1439,78 @@ function ReminderRow({
   const aiProcessing = reminder.labels.includes('ai-to-process')
   const aiFailed = reminder.labels.includes('ai-failed')
 
+  const { pointer, onClick, onKeyDown } = useReminderRowGestures({
+    reminder,
+    isSelectionMode,
+    onComplete,
+    onSelect,
+    onRangeSelect,
+    onOpen,
+  })
+
   return (
     <li
       data-reminder-id={reminder.id}
+      data-reminder-highlight={highlighted ? '' : undefined}
+      ref={highlighted ? scrollRowIntoView : undefined}
       role="option"
       aria-selected={selected}
-      onClick={(e) => onClick(reminder, e)}
-      // Double-click opens the reminder's details, as it opens a task's quick
-      // panel on the dashboard (Trent, 2026-09-05: "why doesn't double-clicking
-      // bring up the modal"). Its two clicks select and then deselect the row
-      // (a lone selection toggles), so afterwards nothing is selected — the
-      // dashboard's double-click leaves the same state.
-      // Same guard the quota rows use: the check circle and Retry stop the
-      // row's click, but dblclick travels separately and would open this on
-      // top of whatever the button just did.
-      onDoubleClick={(e) => {
-        if (fromRowControl(e)) return
-        onOpen(reminder)
-      }}
+      // The row is the keyboard's way in — it has to be focusable for
+      // Enter/Space to reach it at all, and it is what a screen reader reads.
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      onPointerDown={pointer.onPointerDown}
+      onPointerUp={pointer.onPointerUp}
+      onPointerMove={pointer.onPointerMove}
+      onPointerLeave={pointer.onPointerLeave}
+      onPointerCancel={pointer.onPointerUp}
       className={cn(
         // The border is always there, transparent, so the processing pulse has
         // something to color without the row shifting by a pixel.
         'group flex cursor-pointer items-start gap-3 rounded-xl border border-transparent px-2 py-2.5 transition-all duration-200 ease-out select-none',
+        'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
         selected ? 'ring-ring bg-accent ring-2' : 'hover:bg-foreground/[0.04]',
         completing && 'pointer-events-none translate-x-2 opacity-0',
         aiProcessing && 'animate-ai-processing',
+        highlighted && 'animate-row-highlight',
       )}
       data-ai-state={aiProcessing ? 'processing' : aiFailed ? 'failed' : undefined}
     >
-      {/* The circle considers this one item directly and never touches the
-          selection, so it stops the row's click from reaching the handler. */}
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation()
-          onComplete(reminder)
-        }}
-        aria-label={`Mark "${reminder.title}" as considered`}
-        title="Considered"
-        className="border-foreground/20 hover:border-foreground/60 hover:bg-foreground/5 mt-[3px] flex size-6 shrink-0 items-center justify-center rounded-full border-[1.5px] transition-colors"
-      >
-        <Check
-          className="group-hover:text-foreground/40 size-3.5 text-transparent transition-colors"
-          strokeWidth={3}
+      {/* In selection mode the circle becomes a check mark, as the dashboard's
+          done button does — the row's tap is a selection then, and a circle
+          still offering to complete would contradict it. */}
+      {isSelectionMode ? (
+        <Checkbox
+          checked={selected}
+          onCheckedChange={() => onSelect(reminder)}
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={`Select "${reminder.title}"`}
+          className="mt-[3px] size-6 shrink-0"
         />
-      </button>
+      ) : (
+        /* The circle considers this one item directly and never touches the
+           selection, so it stops the row's click from reaching the handler —
+           and its pointer events too, or holding it would turn selection mode
+           on underneath and swap the button out mid-press. */
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onComplete(reminder)
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={`Mark "${reminder.title}" as considered`}
+          title="Considered"
+          className="border-foreground/20 hover:border-foreground/60 hover:bg-foreground/5 mt-[3px] flex size-6 shrink-0 items-center justify-center rounded-full border-[1.5px] transition-colors"
+        >
+          <Check
+            className="group-hover:text-foreground/40 size-3.5 text-transparent transition-colors"
+            strokeWidth={3}
+          />
+        </button>
+      )}
       {/* The notes marker sits inline after the title rather than pinned to
           the right edge: on a wide screen a lone icon across the row reads as
           an unrelated control, and this one is only ever a footnote. */}
@@ -1312,6 +1542,7 @@ function ReminderRow({
                 e.stopPropagation()
                 onRetry(reminder)
               }}
+              onPointerDown={(e) => e.stopPropagation()}
               className="text-foreground/80 hover:text-foreground ml-1.5 underline underline-offset-2"
             >
               Retry
@@ -1341,7 +1572,9 @@ function SearchResults({
   notToday,
   completingIds,
   selectedIds,
-  onRowClick,
+  isSelectionMode,
+  onSelect,
+  onRangeSelect,
   onRowOpen,
   onComplete,
   onRetry,
@@ -1353,7 +1586,9 @@ function SearchResults({
   notToday: Task[]
   completingIds: Set<number>
   selectedIds: Set<number>
-  onRowClick: (task: Task, e: React.MouseEvent) => void
+  isSelectionMode: boolean
+  onSelect: (task: Task) => void
+  onRangeSelect: (task: Task) => void
   onRowOpen: (task: Task) => void
   onComplete: (task: Task) => void
   onRetry: (task: Task) => void
@@ -1382,7 +1617,10 @@ function SearchResults({
               onExpand={NO_OP}
               completingIds={completingIds}
               selectedIds={selectedIds}
-              onRowClick={onRowClick}
+              isSelectionMode={isSelectionMode}
+              highlightId={null}
+              onSelect={onSelect}
+              onRangeSelect={onRangeSelect}
               onRowOpen={onRowOpen}
               onComplete={onComplete}
               onRetry={onRetry}
@@ -1411,20 +1649,35 @@ function NotTodayFold({
   items,
   onOpen,
   forceOpen = false,
+  requestOpen = false,
+  highlightId = null,
 }: {
   items: Task[]
   onOpen: (task: Task) => void
   /** Search results are shown, never folded away. */
   forceOpen?: boolean
+  /**
+   * A deep link landed on a thought that lives in here. Opens the fold once,
+   * and then gets out of the way — unlike `forceOpen`, which also takes the
+   * toggle away, and the user must be able to fold this again.
+   */
+  requestOpen?: boolean
+  /** The deep-linked row: scrolled to and flashed, as in a slot. */
+  highlightId?: number | null
 }) {
-  const [userOpen, setUserOpen] = useState(false)
-  const open = forceOpen || userOpen
-  const setOpen = forceOpen ? NO_OP : setUserOpen
+  // `requestOpen` moves the DEFAULT rather than forcing the fold: a deep link
+  // opens it, and the moment the user touches the caret their answer (null
+  // until then) takes over, so the link can never hold it open against them.
+  const [userOpen, setUserOpen] = useState<boolean | null>(null)
+  const open = forceOpen || (userOpen ?? requestOpen)
+  const toggle = () => {
+    if (!forceOpen) setUserOpen(!open)
+  }
   return (
     <div className="bg-muted/30 mt-3 rounded-2xl pb-1" data-not-today>
       <button
         type="button"
-        onClick={() => setOpen((o) => !o)}
+        onClick={toggle}
         aria-expanded={open}
         className="hover:text-foreground flex min-h-11 w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors"
       >
@@ -1440,8 +1693,15 @@ function NotTodayFold({
         <ul className="space-y-0.5 px-1">
           {items.map((task) => {
             const mark = cadenceMark(task.rrule)
+            const highlighted = highlightId === task.id
             return (
-              <li key={task.id} data-not-today-id={task.id}>
+              <li
+                key={task.id}
+                data-not-today-id={task.id}
+                data-reminder-highlight={highlighted ? '' : undefined}
+                ref={highlighted ? scrollRowIntoView : undefined}
+                className={cn('rounded-xl', highlighted && 'animate-row-highlight')}
+              >
                 <button
                   type="button"
                   onClick={() => onOpen(task)}

--- a/src/hooks/useReminders.ts
+++ b/src/hooks/useReminders.ts
@@ -69,6 +69,20 @@ export interface UseRemindersReturn {
    */
   rowLeft: (id: number) => void
   /**
+   * A row reporting that it is on screen. Returns its own deregistration, so a
+   * row can call it straight out of an effect. Only a mounted row can report
+   * its animation finishing, so only a mounted row's completion is allowed to
+   * hold anything back — see `completeIds`.
+   */
+  registerRow: (id: number) => () => void
+  /**
+   * True once a fetch has resolved since this hook mounted. The module cache
+   * paints the surface instantly on a revisit, so `loading === false` is not
+   * the same as "this is the current truth" — anything that must not act on
+   * stale data (the `?reminder=` deep link) waits for this instead.
+   */
+  hydrated: boolean
+  /**
    * Complete ("consider") a set of reminders at once — a selection made on the
    * surface, or a whole slot. One bulk call, one undo entry.
    */
@@ -216,6 +230,9 @@ export function useReminders({
   const [error, setError] = useState<string | null>(null)
   const [completingIds, setCompletingIds] = useState<Set<number>>(new Set())
   const [consideredAny, setConsideredAny] = useState(false)
+  const consideredAnyRef = useRef(consideredAny)
+  consideredAnyRef.current = consideredAny
+  const [hydrated, setHydrated] = useState(false)
 
   // Callbacks live in a ref so `refresh` and `complete` stay referentially
   // stable — the parent registers `refresh` in a ref and calls it from its own
@@ -243,6 +260,8 @@ export function useReminders({
    */
   const leavingIdsRef = useRef<Set<number>>(new Set())
   const heldRefreshRef = useRef(false)
+  /** IDs with a row actually rendered right now (see `registerRow`). */
+  const mountedIdsRef = useRef<Set<number>>(new Set())
   // The rendered groups, for the snapshot a failed completion restores.
   const groupsRef = useRef<ReminderGroup[]>(groups)
   groupsRef.current = groups
@@ -267,6 +286,7 @@ export function useReminders({
       setHasAny(nextHasAny)
       setNotToday(nextNotToday)
       setError(null)
+      setHydrated(true)
     } catch (err) {
       // A failed background refresh over cached data is not an error state —
       // the stale render plus the next successful refresh beats an error
@@ -309,21 +329,74 @@ export function useReminders({
    * tap and any acknowledgement.) A failed call restores the snapshot and
    * turns the toast's promise into a no-op.
    */
+  /** Move ids out of `reminders` and in behind the slot's counter. */
+  const commitConsidered = useCallback((ids: number[]) => {
+    if (ids.length === 0) return
+    const idSet = new Set(ids)
+    setGroups((prev) => {
+      const next = prev.map((g) => {
+        const considered = g.reminders.filter((r) => idSet.has(r.id))
+        if (considered.length === 0) return g
+        const reminders = g.reminders.filter((r) => !idSet.has(r.id))
+        return {
+          ...g,
+          reminders,
+          count: reminders.length,
+          consideredItems: [...considered, ...g.consideredItems],
+          considered: considered.length + g.consideredItems.length,
+        }
+      })
+      if (remindersCache) setRemindersCache({ ...remindersCache, groups: next })
+      return next
+    })
+  }, [])
+
+  /**
+   * Run the refresh that was held while rows were collapsing, if the last of
+   * them has now gone. Every path that empties `leavingIdsRef` ends here —
+   * a held refresh that nothing releases would silently switch this surface
+   * off for the rest of the session.
+   */
+  const releaseHeldRefresh = useCallback(() => {
+    if (leavingIdsRef.current.size > 0 || !heldRefreshRef.current) return
+    heldRefreshRef.current = false
+    void refresh()
+  }, [refresh])
+
+  const registerRow = useCallback((id: number) => {
+    mountedIdsRef.current.add(id)
+    return () => {
+      mountedIdsRef.current.delete(id)
+    }
+  }, [])
+
   const completeIds = useCallback(
-    async (tasks: Task[], message: string) => {
-      const ids = tasks.map((t) => t.id)
+    async (tasks: Task[], message: (considered: number) => string) => {
+      // One completion per reminder in flight. Two Enters inside the collapse,
+      // or a slot sweep confirmed over a row that is still going, would
+      // otherwise send /done twice — and a recurring reminder would advance two
+      // occurrences for one intention.
+      const fresh = tasks.filter((t) => !pendingIdsRef.current.has(t.id))
+      const ids = fresh.map((t) => t.id)
       if (ids.length === 0) return
-      for (const id of ids) {
-        pendingIdsRef.current.add(id)
-        leavingIdsRef.current.add(id)
-      }
-      // The rows do not leave `groups` here. They are marked as leaving, which
-      // is what draws them struck through and inert while they collapse; each
-      // one calls `rowLeft` when its animation ends, and THAT is what moves it
-      // behind the slot's counter. Holding the position is the whole point:
-      // see `rowLeft` for the double-click this prevents.
+      // Only a row that is ON SCREEN can report its animation finishing, so
+      // only those are allowed to hold their place — and with it the refresh.
+      // Anything swept out of a folded slot, or from under a "Show all N" cap,
+      // has no row to reflow under anyone's pointer, so it leaves at once, the
+      // way everything used to.
+      const onScreen = ids.filter((id) => mountedIdsRef.current.has(id))
+      const offScreen = ids.filter((id) => !mountedIdsRef.current.has(id))
+      for (const id of ids) pendingIdsRef.current.add(id)
+      for (const id of onScreen) leavingIdsRef.current.add(id)
+      // The on-screen rows do not leave `groups` here. They are marked as
+      // leaving, which is what draws them struck through and inert while they
+      // collapse; each one calls `rowLeft` when its animation ends, and THAT is
+      // what moves it behind the slot's counter. Holding the position is the
+      // whole point: see `rowLeft` for the double-click this prevents.
       const snapshot = groupsRef.current
-      setCompletingIds((prev) => new Set([...prev, ...ids]))
+      const hadConsidered = consideredAnyRef.current
+      if (onScreen.length > 0) setCompletingIds((prev) => new Set([...prev, ...onScreen]))
+      commitConsidered(offScreen)
       setConsideredAny(true)
 
       const request = (async () => {
@@ -342,7 +415,7 @@ export function useReminders({
       // Undo waits for the completion to be recorded, then undoes exactly it.
       let settledOk = false
       showToast({
-        message,
+        message: message(ids.length),
         type: 'success',
         action: {
           label: 'Undo',
@@ -356,10 +429,10 @@ export function useReminders({
         await request
         settledOk = true
       } catch {
-        // The thoughts never went anywhere the user can see if they are still
-        // collapsing, so this puts them back in place rather than re-inserting
-        // them: clear the leaving marks and restore whatever had been
-        // committed by a row that already finished.
+        // A thought still collapsing never went anywhere the user can see, so
+        // this puts it back in place rather than re-inserting it: drop the
+        // leaving marks, restore whatever a row that already finished had
+        // committed, and take back the session flag if this was the first one.
         for (const id of ids) leavingIdsRef.current.delete(id)
         setCompletingIds((prev) => {
           const next = new Set(prev)
@@ -368,7 +441,11 @@ export function useReminders({
         })
         if (remindersCache) setRemindersCache({ ...remindersCache, groups: snapshot })
         setGroups(snapshot)
+        if (!hadConsidered) setConsideredAny(false)
         showToast({ message: 'Could not complete reminders', type: 'error' })
+        // Clearing those marks may have emptied the leaving set, and a refresh
+        // held behind it must not be stranded by a failure.
+        releaseHeldRefresh()
       } finally {
         for (const id of ids) pendingIdsRef.current.delete(id)
         // A refresh after a confirmed completion converges the cache with the
@@ -377,7 +454,7 @@ export function useReminders({
         if (settledOk) void refresh()
       }
     },
-    [refresh],
+    [refresh, commitConsidered, releaseHeldRefresh],
   )
 
   /**
@@ -405,37 +482,18 @@ export function useReminders({
         next.delete(id)
         return next
       })
-      setGroups((prev) => {
-        const next = prev.map((g) => {
-          const considered = g.reminders.find((r) => r.id === id)
-          if (!considered) return g
-          const reminders = g.reminders.filter((r) => r.id !== id)
-          // It moves behind the slot's counter as it goes, so the progress bar
-          // and the "put back" list agree with the row that just left.
-          const consideredItems = [considered, ...g.consideredItems]
-          return {
-            ...g,
-            reminders,
-            count: reminders.length,
-            consideredItems,
-            considered: consideredItems.length,
-          }
-        })
-        if (remindersCache) setRemindersCache({ ...remindersCache, groups: next })
-        return next
-      })
+      // It moves behind the slot's counter as it goes, so the progress bar and
+      // the "put back" list agree with the row that just left.
+      commitConsidered([id])
       // Any refresh that arrived during the collapse was held rather than
       // applied over a row that was still on screen. Run it now.
-      if (leavingIdsRef.current.size === 0 && heldRefreshRef.current) {
-        heldRefreshRef.current = false
-        void refresh()
-      }
+      releaseHeldRefresh()
     },
-    [refresh],
+    [commitConsidered, releaseHeldRefresh],
   )
 
   const completeMany = useCallback(
-    (tasks: Task[]) => completeIds(tasks, `Considered ${tasks.length}`),
+    (tasks: Task[]) => completeIds(tasks, (n) => `Considered ${n}`),
     [completeIds],
   )
 
@@ -443,7 +501,7 @@ export function useReminders({
   const remove = useRemove({ setGroups, refresh, pendingIdsRef, callbacksRef })
 
   const complete = useCallback(
-    (task: Task) => completeIds([task], `Considered \u201c${task.title}\u201d`),
+    (task: Task) => completeIds([task], () => `Considered \u201c${task.title}\u201d`),
     [completeIds],
   )
 
@@ -509,6 +567,8 @@ export function useReminders({
     completeMany,
     completeGroup,
     rowLeft,
+    registerRow,
+    hydrated,
     putBack,
     remove,
     refresh,

--- a/src/hooks/useReminders.ts
+++ b/src/hooks/useReminders.ts
@@ -57,6 +57,18 @@ export interface UseRemindersReturn {
   consideredAny: boolean
   complete: (task: Task) => Promise<void>
   /**
+   * "The row has finished leaving the screen." Called by the row itself when
+   * its collapse animation ends (or when it unmounts mid-collapse), and only
+   * then does the considered reminder leave `groups`.
+   *
+   * Completion used to remove the row the instant it was clicked, which made
+   * the list reflow under a stationary pointer: the second click of a
+   * double-click landed on whichever thought had slid up into the gap and
+   * considered that one too. Now the row stays where it is, inert, until it
+   * has visibly gone.
+   */
+  rowLeft: (id: number) => void
+  /**
    * Complete ("consider") a set of reminders at once — a selection made on the
    * surface, or a whole slot. One bulk call, one undo entry.
    */
@@ -222,10 +234,26 @@ export function useReminders({
   // The same in the other direction: a put-back whose request is still out.
   const pendingIdsRef = useRef<Set<number>>(new Set())
   const restoringIdsRef = useRef<Set<number>>(new Set())
+  /**
+   * IDs whose row is still on screen, collapsing. They are still in `groups`,
+   * so a server payload — which no longer lists them — cannot be applied
+   * without deciding where to put them back. Rather than guess, `refresh`
+   * holds until the last one has gone and `rowLeft` runs the held one; the
+   * wait is the length of one animation.
+   */
+  const leavingIdsRef = useRef<Set<number>>(new Set())
+  const heldRefreshRef = useRef(false)
+  // The rendered groups, for the snapshot a failed completion restores.
+  const groupsRef = useRef<ReminderGroup[]>(groups)
+  groupsRef.current = groups
   const stripPending = (incoming: ReminderGroup[]) =>
     reconcileInFlight(incoming, pendingIdsRef.current, restoringIdsRef.current)
 
   const refresh = useCallback(async () => {
+    if (leavingIdsRef.current.size > 0) {
+      heldRefreshRef.current = true
+      return
+    }
     try {
       const res = await fetch('/api/reminders')
       if (!res.ok) throw new Error('Failed to load reminders')
@@ -285,30 +313,17 @@ export function useReminders({
     async (tasks: Task[], message: string) => {
       const ids = tasks.map((t) => t.id)
       if (ids.length === 0) return
-      const idSet = new Set(ids)
-      for (const id of ids) pendingIdsRef.current.add(id)
+      for (const id of ids) {
+        pendingIdsRef.current.add(id)
+        leavingIdsRef.current.add(id)
+      }
+      // The rows do not leave `groups` here. They are marked as leaving, which
+      // is what draws them struck through and inert while they collapse; each
+      // one calls `rowLeft` when its animation ends, and THAT is what moves it
+      // behind the slot's counter. Holding the position is the whole point:
+      // see `rowLeft` for the double-click this prevents.
+      const snapshot = groupsRef.current
       setCompletingIds((prev) => new Set([...prev, ...ids]))
-      let snapshot: ReminderGroup[] | null = null
-      setGroups((prev) => {
-        snapshot = prev
-        const next = prev.map((g) => {
-          const remaining = g.reminders.filter((r) => !idSet.has(r.id))
-          if (remaining.length === g.reminders.length) return g
-          const considered = g.reminders.filter((r) => idSet.has(r.id))
-          // The considered ones move behind the counter at once, so the
-          // progress and the "put back" list agree with the row that just left.
-          const consideredItems = [...considered, ...g.consideredItems]
-          return {
-            ...g,
-            reminders: remaining,
-            count: remaining.length,
-            consideredItems,
-            considered: consideredItems.length,
-          }
-        })
-        if (remindersCache) setRemindersCache({ ...remindersCache, groups: next })
-        return next
-      })
       setConsideredAny(true)
 
       const request = (async () => {
@@ -341,23 +356,79 @@ export function useReminders({
         await request
         settledOk = true
       } catch {
-        if (snapshot) {
-          const restored = snapshot
-          if (remindersCache) setRemindersCache({ ...remindersCache, groups: restored })
-          setGroups(restored)
-        }
-        showToast({ message: 'Could not complete reminders', type: 'error' })
-      } finally {
-        for (const id of ids) pendingIdsRef.current.delete(id)
+        // The thoughts never went anywhere the user can see if they are still
+        // collapsing, so this puts them back in place rather than re-inserting
+        // them: clear the leaving marks and restore whatever had been
+        // committed by a row that already finished.
+        for (const id of ids) leavingIdsRef.current.delete(id)
         setCompletingIds((prev) => {
           const next = new Set(prev)
           for (const id of ids) next.delete(id)
           return next
         })
+        if (remindersCache) setRemindersCache({ ...remindersCache, groups: snapshot })
+        setGroups(snapshot)
+        showToast({ message: 'Could not complete reminders', type: 'error' })
+      } finally {
+        for (const id of ids) pendingIdsRef.current.delete(id)
         // A refresh after a confirmed completion converges the cache with the
         // server (the recurring case: a considered reminder is gone until its next
         // occurrence, which only the server knows).
         if (settledOk) void refresh()
+      }
+    },
+    [refresh],
+  )
+
+  /**
+   * A considered row has finished collapsing — now it leaves the data.
+   *
+   * This is the other half of the deferral in `completeIds`, and the reason
+   * for it: with removal on click, the list reflowed under a pointer that had
+   * not moved, so the second click of a double-click landed on whichever
+   * thought slid up into the gap and considered that one too (measured on dev:
+   * one double-click took two reminders). The row now holds its place, inert,
+   * until it has visibly gone.
+   *
+   * Idempotent, because two things call it: the row's `animationend`, and the
+   * row unmounting while still mid-collapse (a folded slot, a navigation) —
+   * without that second path a row that never finished animating would hold
+   * `refresh` shut.
+   */
+  const rowLeft = useCallback(
+    (id: number) => {
+      if (!leavingIdsRef.current.has(id)) return
+      leavingIdsRef.current.delete(id)
+      setCompletingIds((prev) => {
+        if (!prev.has(id)) return prev
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+      setGroups((prev) => {
+        const next = prev.map((g) => {
+          const considered = g.reminders.find((r) => r.id === id)
+          if (!considered) return g
+          const reminders = g.reminders.filter((r) => r.id !== id)
+          // It moves behind the slot's counter as it goes, so the progress bar
+          // and the "put back" list agree with the row that just left.
+          const consideredItems = [considered, ...g.consideredItems]
+          return {
+            ...g,
+            reminders,
+            count: reminders.length,
+            consideredItems,
+            considered: consideredItems.length,
+          }
+        })
+        if (remindersCache) setRemindersCache({ ...remindersCache, groups: next })
+        return next
+      })
+      // Any refresh that arrived during the collapse was held rather than
+      // applied over a row that was still on screen. Run it now.
+      if (leavingIdsRef.current.size === 0 && heldRefreshRef.current) {
+        heldRefreshRef.current = false
+        void refresh()
       }
     },
     [refresh],
@@ -437,6 +508,7 @@ export function useReminders({
     complete,
     completeMany,
     completeGroup,
+    rowLeft,
     putBack,
     remove,
     refresh,

--- a/tests/e2e/reminders.spec.ts
+++ b/tests/e2e/reminders.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { test, expect } from './fixtures'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 import { DateTime } from 'luxon'
 
 /** The seeded test user's timezone — slot assignment is done in local time. */
@@ -83,6 +83,26 @@ async function openAllSlots(page: Page) {
     // Re-query each time: opening a slot re-renders the list.
     await surface.getByRole('button', { expanded: false }).first().click()
   }
+}
+
+/**
+ * Press and hold a row until it is selected — the gesture that replaced a click
+ * for selecting (Trent, 2026-09-11), since a click now considers the thought.
+ *
+ * The hold is held open by an assertion rather than a timer: the row going
+ * `aria-selected` IS the 400ms elapsing, so there is nothing to tune and
+ * nothing to race. Releasing afterwards lets the browser synthesise its click,
+ * which is exactly the path the hook has to swallow — if it ever stopped
+ * swallowing it, every test using this would consider the row it just selected.
+ */
+async function longPressRow(page: Page, row: Locator): Promise<void> {
+  await row.scrollIntoViewIfNeeded()
+  const box = await row.boundingBox()
+  if (!box) throw new Error('the row is not on screen')
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  await page.mouse.down()
+  await expect(row).toHaveAttribute('aria-selected', 'true')
+  await page.mouse.up()
 }
 
 test.describe('Reminders surface', () => {
@@ -234,7 +254,38 @@ test.describe('Reminders surface', () => {
     }
   })
 
-  test('selects like the dashboard: click, shift-click a range, act from the bar', async ({
+  test('a tap anywhere on a row considers it, and Undo puts it back', async ({
+    authenticatedPage: page,
+  }) => {
+    const ids = [
+      await createReminder(page, { title: 'A thought to tap away', due_at: todayAt(7) }),
+      await createReminder(page, { title: 'A thought left alone', due_at: todayAt(7) }),
+    ]
+
+    try {
+      await openReminders(page)
+      await openAllSlots(page)
+      const row = (title: string) => page.locator('li[data-reminder-id]', { hasText: title })
+
+      // Trent, 2026-09-11: "I should be able to just tap reminders pretty much
+      // anywhere to mark them done." The click lands on the title, not the
+      // circle, and does what the circle does.
+      await row('A thought to tap away').click()
+      await expect(page).toHaveURL(/\/reminders/)
+      await expect(row('A thought to tap away')).toHaveCount(0)
+      await expect(row('A thought left alone')).toBeVisible()
+      await expect(page.getByText('Considered \u201cA thought to tap away\u201d')).toBeVisible()
+      // A tap is not a selection: the bar never appears on the way.
+      await expect(page.getByRole('button', { name: 'Clear selection' })).toHaveCount(0)
+
+      await toastUndo(page).click()
+      await expect(row('A thought to tap away')).toBeVisible()
+    } finally {
+      await deleteTasks(page, ids)
+    }
+  })
+
+  test('press and hold selects, and the bar acts on the selection', async ({
     authenticatedPage: page,
   }) => {
     const ids = [
@@ -248,10 +299,12 @@ test.describe('Reminders surface', () => {
       await openAllSlots(page)
       const row = (title: string) => page.locator('li[data-reminder-id]', { hasText: title })
 
-      // A plain click selects the row and raises the bar — it does NOT navigate.
-      await row('First thought of the range').click()
+      // The hold turns selection mode on and checks the row. Crucially it does
+      // NOT also consider it: the click the release synthesises is swallowed.
+      await longPressRow(page, row('First thought of the range'))
       await expect(page).toHaveURL(/\/reminders/)
-      await expect(row('First thought of the range')).toHaveAttribute('aria-selected', 'true')
+      await expect(row('First thought of the range')).toBeVisible()
+      await expect(row('First thought of the range').getByRole('checkbox')).toBeVisible()
       await expect(page.getByRole('button', { name: 'Considered', exact: true })).toBeVisible()
       // Single selection offers Details; that is the deliberate way to open one.
       await expect(page.getByRole('button', { name: 'Details', exact: true })).toBeVisible()
@@ -263,6 +316,14 @@ test.describe('Reminders surface', () => {
       await expect(page.getByText('3 selected')).toBeVisible()
       await expect(page.getByRole('button', { name: 'Details', exact: true })).toBeVisible()
 
+      // Inside selection mode a plain click toggles, and never considers —
+      // out here a tap is destructive, so it must not silently become one.
+      await row('Second thought of the range').click()
+      await expect(row('Second thought of the range')).toHaveAttribute('aria-selected', 'false')
+      await expect(page.getByText('2 selected')).toBeVisible()
+      await row('Second thought of the range').click()
+      await expect(page.getByText('3 selected')).toBeVisible()
+
       // One action considers the whole selection, and one Undo brings it all back.
       await page.getByRole('button', { name: 'Considered', exact: true }).click()
       await expect(row('First thought of the range')).toHaveCount(0)
@@ -273,11 +334,68 @@ test.describe('Reminders surface', () => {
       await expect(row('Second thought of the range')).toBeVisible()
       await expect(row('Third thought of the range')).toBeVisible()
 
-      // Escape clears a selection.
-      await row('Second thought of the range').click()
+      // Escape clears a selection, and the circles come back with it — so the
+      // next tap considers again rather than selecting.
+      await longPressRow(page, row('Second thought of the range'))
       await expect(page.getByRole('button', { name: 'Considered', exact: true })).toBeVisible()
       await page.keyboard.press('Escape')
       await expect(page.getByRole('button', { name: 'Considered', exact: true })).toHaveCount(0)
+      await expect(row('Second thought of the range').getByRole('checkbox')).toHaveCount(0)
+      await expect(
+        row('Second thought of the range').getByRole('button', {
+          name: 'Mark "Second thought of the range" as considered',
+        }),
+      ).toBeVisible()
+    } finally {
+      await deleteTasks(page, ids)
+    }
+  })
+
+  test('?reminder=<id> brings that thought on screen without opening it', async ({
+    authenticatedPage: page,
+  }) => {
+    // The iOS widget's deep link. Two shapes: one in a slot, and one with no
+    // occurrence today, which lives behind the "Not today" fold and so proves
+    // the link opens whatever is hiding it.
+    await page.setViewportSize({ width: 1280, height: 800 })
+    const RRULE_DAYS = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']
+    const today = DateTime.now().setZone(TEST_TZ).weekday - 1
+    const anotherDay = RRULE_DAYS[(today + 3) % 7]
+    const ids = [
+      await createReminder(page, {
+        title: 'A thought the widget links to',
+        rrule: 'FREQ=DAILY;BYHOUR=7;BYMINUTE=0',
+        due_at: todayAt(7),
+      }),
+      await createReminder(page, {
+        title: 'A thought for another day',
+        rrule: `FREQ=WEEKLY;BYDAY=${anotherDay};BYHOUR=7;BYMINUTE=0`,
+      }),
+    ]
+
+    try {
+      await page.goto(`/reminders?reminder=${ids[0]}`)
+      const linked = page.locator(`li[data-reminder-id="${ids[0]}"]`)
+      await expect(linked).toHaveAttribute('data-reminder-highlight', '')
+      await expect(linked).toBeInViewport()
+      // A link is a place to look, not an edit. Nothing opens.
+      await expect(page.getByRole('dialog')).toHaveCount(0)
+      // The param is spent, so a reload does not flash the same row again.
+      await expect(page).toHaveURL('/reminders')
+
+      await page.goto(`/reminders?reminder=${ids[1]}`)
+      const folded = page.locator(`li[data-not-today-id="${ids[1]}"]`)
+      await expect(folded).toHaveAttribute('data-reminder-highlight', '')
+      await expect(folded).toBeInViewport()
+      await expect(page.getByRole('dialog')).toHaveCount(0)
+      await expect(page).toHaveURL('/reminders')
+
+      // The link opened the fold; it did not take it over — closing it still works.
+      await page
+        .locator('[data-not-today]')
+        .getByRole('button', { name: /Not today/ })
+        .click()
+      await expect(folded).toHaveCount(0)
     } finally {
       await deleteTasks(page, ids)
     }
@@ -513,7 +631,7 @@ test.describe('Reminders trash', () => {
       await openReminders(page)
       await openAllSlots(page)
       const row = (title: string) => page.locator('li[data-reminder-id]', { hasText: title })
-      await row('A thought to let go of').click()
+      await longPressRow(page, row('A thought to let go of'))
       // The row and the toast are optimistic; the server's answer is what
       // the API check below depends on (on the dev server a first hit of a
       // route compiles it, which can take seconds), so wait for it by name.
@@ -575,7 +693,7 @@ test.describe('Reminder details', () => {
         page.locator(`[data-slot-group="${slot}"] li[data-reminder-id]`, {
           hasText: 'A thought for the evening',
         })
-      await row('Early morning').click()
+      await longPressRow(page, row('Early morning'))
       await page.getByRole('button', { name: 'Details', exact: true }).click()
 
       const dialog = page.getByRole('dialog', { name: 'Reminder' })
@@ -618,7 +736,7 @@ test.describe('Reminder details', () => {
     }
   })
 
-  test('double-click opens the editor, and a row says when it is not every day', async ({
+  test('hold then Details opens the editor, and a row says when it is not every day', async ({
     authenticatedPage: page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 800 })
@@ -650,35 +768,66 @@ test.describe('Reminder details', () => {
       )
       await expect(row('A thought for every day').locator('[data-cadence-mark]')).toHaveCount(0)
 
-      await row('A thought for every day').dblclick()
+      // Hold, then Details: the only way in to a reminder's editor now that a
+      // plain tap considers it (Trent, 2026-09-11: "we just tap and hold and
+      // then click Details with the item checked").
+      await longPressRow(page, row('A thought for every day'))
+      await page.getByRole('button', { name: 'Details', exact: true }).click()
       const dialog = page.getByRole('dialog', { name: 'Reminder' })
       await expect(dialog).toBeVisible()
       await expect(dialog).toContainText('A thought for every day')
       await dialog.getByRole('button', { name: 'Cancel', exact: true }).click()
       await expect(dialog).toHaveCount(0)
-      // The two clicks selected and then deselected the row: nothing is left
-      // selected, as after the dashboard's double-click.
+
+      // The row is still selected behind the closed editor — the hold said so
+      // and nothing since has said otherwise — and Escape is the way out.
+      await expect(page.getByRole('button', { name: 'Clear selection' })).toBeVisible()
+      await page.keyboard.press('Escape')
       await expect(page.getByRole('button', { name: 'Clear selection' })).toHaveCount(0)
 
-      // The hazard: a row sitting where the selection bar appears. The first
-      // click selects it and the bar slides over it, so the second click of
-      // the double-click lands on the bar — it must open the editor, not
-      // press whatever button it fell on (on dev it landed on "Considered").
-      await page.setViewportSize({ width: 1280, height: 480 })
-      const target = row('A thought for some days')
-      await target.evaluate((el) => {
-        const r = el.getBoundingClientRect()
-        window.scrollTo(0, window.scrollY + r.bottom - (window.innerHeight - 40))
-      })
-      await target.dblclick()
-      await expect(dialog).toBeVisible()
-      await expect(dialog).toContainText('A thought for some days')
-      await dialog.getByRole('button', { name: 'Cancel', exact: true }).click()
-      await expect(dialog).toHaveCount(0)
-      await expect(target).toBeVisible()
+      // Neither the hold nor the editor considered anything: the thoughts are
+      // both still on the surface with no completion behind them.
+      await expect(row('A thought for every day')).toBeVisible()
+      await expect(row('A thought for some days')).toBeVisible()
       expect(await taskField(page, ids[0], 'completion_count')).toBe(0)
+      expect(await taskField(page, ids[1], 'completion_count')).toBe(0)
     } finally {
       await deleteTasks(page, ids)
+    }
+  })
+
+  test('the keyboard reaches a reminder with no pointer at all', async ({
+    authenticatedPage: page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    const id = await createReminder(page, {
+      title: 'A thought for the keyboard',
+      due_at: todayAt(7),
+    })
+    try {
+      await openReminders(page)
+      await openAllSlots(page)
+      const row = page.locator(`li[data-reminder-id="${id}"]`)
+
+      // A press-and-hold has no keyboard equivalent, so the row offers the
+      // destination directly: Cmd/Ctrl+Enter opens its details.
+      await row.press('ControlOrMeta+Enter')
+      const dialog = page.getByRole('dialog', { name: 'Reminder' })
+      await expect(dialog).toBeVisible()
+      await expect(dialog).toContainText('A thought for the keyboard')
+      await dialog.getByRole('button', { name: 'Cancel', exact: true }).click()
+      await expect(dialog).toHaveCount(0)
+
+      // And Enter on the focused row is the tap.
+      await row.press('Enter')
+      await expect(page.locator(`li[data-reminder-id="${id}"]`)).toHaveCount(0)
+      await expect(
+        page.getByText('Considered \u201cA thought for the keyboard\u201d'),
+      ).toBeVisible()
+      await toastUndo(page).click()
+      await expect(page.locator(`li[data-reminder-id="${id}"]`)).toBeVisible()
+    } finally {
+      await deleteTasks(page, [id])
     }
   })
 
@@ -707,7 +856,8 @@ test.describe('Reminder details', () => {
       await openReminders(page)
       await openAllSlots(page)
       const row = (title: string) => page.locator('li[data-reminder-id]', { hasText: title })
-      await row('A thought every day').click()
+      await longPressRow(page, row('A thought every day'))
+      // Cmd/Ctrl-click still adds to a selection, as on the dashboard.
       await row('A thought on some days').click({ modifiers: ['ControlOrMeta'] })
       await expect(page.getByText('2 selected')).toBeVisible()
       await page.getByRole('button', { name: 'Details', exact: true }).click()
@@ -838,7 +988,8 @@ test.describe('Reminder details', () => {
       const rows = page.locator('[data-slot-group="Early morning"] li[data-reminder-id]')
       await expect(rows.nth(0)).toContainText('A quiet thought')
 
-      await rows.nth(1).dblclick()
+      await longPressRow(page, rows.nth(1))
+      await page.getByRole('button', { name: 'Details', exact: true }).click()
       const dialog = page.getByRole('dialog', { name: 'Reminder', exact: true })
       await expect(dialog.locator('[data-priority-chip="0"]')).toHaveAttribute(
         'aria-pressed',
@@ -869,9 +1020,10 @@ test.describe('Reminder details', () => {
     try {
       await openReminders(page)
       await openAllSlots(page)
-      await page
-        .locator('li[data-reminder-id]', { hasText: 'A thought with a date but no rule' })
-        .click()
+      await longPressRow(
+        page,
+        page.locator('li[data-reminder-id]', { hasText: 'A thought with a date but no rule' }),
+      )
       await page.getByRole('button', { name: 'Details', exact: true }).click()
       const dialog = page.getByRole('dialog', { name: 'Reminder' })
       await expect(dialog.locator('[data-cadence="once"]')).toHaveAttribute('aria-pressed', 'true')
@@ -934,7 +1086,10 @@ test.describe('Reminder details', () => {
     try {
       await openReminders(page)
       await openAllSlots(page)
-      await page.locator('li[data-reminder-id]', { hasText: 'A thought worth opening' }).click()
+      await longPressRow(
+        page,
+        page.locator('li[data-reminder-id]', { hasText: 'A thought worth opening' }),
+      )
       await page.getByRole('button', { name: 'Details', exact: true }).click()
       await page
         .getByRole('dialog', { name: 'Reminder' })
@@ -959,7 +1114,10 @@ test.describe('Reminder details', () => {
     try {
       await openReminders(page)
       await openAllSlots(page)
-      await page.locator('li[data-reminder-id]', { hasText: 'A thought on the phone' }).click()
+      await longPressRow(
+        page,
+        page.locator('li[data-reminder-id]', { hasText: 'A thought on the phone' }),
+      )
       await page.getByRole('button', { name: 'Details', exact: true }).click()
       const sheet = page.getByRole('dialog', { name: 'Reminder' })
       await expect(sheet).toBeVisible()

--- a/tests/e2e/reminders.spec.ts
+++ b/tests/e2e/reminders.spec.ts
@@ -403,6 +403,138 @@ test.describe('Reminders surface', () => {
     }
   })
 
+  test('a thought the AI is still reading leaves like any other, and the surface keeps refreshing', async ({
+    authenticatedPage: page,
+  }) => {
+    // Three animations want the row's single `animation` property: the leaving
+    // collapse, the AI pulse, the deep-link flash. If the pulse wins, the
+    // collapse never ends, the row never reports itself gone, and the refresh
+    // held behind it switches this surface off for the rest of the session.
+    // `ai-to-process` is what the quick add sets on everything it creates.
+    const ids: number[] = [
+      await createReminder(page, {
+        title: 'A thought the AI is still reading',
+        rrule: 'FREQ=DAILY;BYHOUR=7;BYMINUTE=0',
+        labels: ['ai-to-process'],
+      }),
+    ]
+    try {
+      await openReminders(page)
+      await openAllSlots(page)
+      const row = page.locator(`li[data-reminder-id="${ids[0]}"]`)
+      await expect(row).toHaveAttribute('data-ai-state', 'processing')
+
+      await row.click()
+      await expect(page.locator(`li[data-reminder-id="${ids[0]}"]`)).toHaveCount(0)
+
+      // The proof that nothing is stuck: something created elsewhere still
+      // reaches this screen. A held refresh would drop it in silence.
+      const later = await createReminder(page, {
+        title: 'A thought added afterwards',
+        due_at: todayAt(7),
+      })
+      ids.push(later)
+      await expect(page.locator(`li[data-reminder-id="${later}"]`)).toBeVisible({ timeout: 15000 })
+    } finally {
+      await deleteTasks(page, ids)
+    }
+  })
+
+  test('a sweep reaches a folded slot, whose rows cannot report themselves gone', async ({
+    authenticatedPage: page,
+  }) => {
+    // "Considered all so far" takes every started slot, folded ones included —
+    // and a folded slot renders no rows, so nothing in it can report a collapse
+    // finishing. Those ids have to leave at once instead of holding the screen.
+    const passed = DateTime.now().minus({ hours: 1 })
+    const soFar = passed.hasSame(DateTime.now(), 'day')
+      ? passed
+      : DateTime.now().startOf('day').plus({ minutes: 1 })
+    const ids: number[] = [
+      await createReminder(page, { title: 'Folded thought one', due_at: soFar.toUTC().toISO() }),
+      await createReminder(page, { title: 'Folded thought two', due_at: soFar.toUTC().toISO() }),
+    ]
+    try {
+      await openReminders(page)
+      await openAllSlots(page)
+      // Held by its label, not by the text of a row the sweep is about to take.
+      const label = await page
+        .locator('[data-slot-group]', { hasText: 'Folded thought one' })
+        .getAttribute('data-slot-group')
+      const slot = page.locator(`[data-slot-group="${label}"]`)
+      await slot.getByRole('button', { expanded: true }).first().click()
+      await expect(slot.locator('li[data-reminder-id]')).toHaveCount(0)
+
+      await page.getByRole('button', { name: /^Mark all 2 waiting so far/ }).click()
+      await page
+        .getByRole('alertdialog')
+        .getByRole('button', { name: /^Consider all 2$/ })
+        .click()
+
+      // The counters and the headline move even though no row was on screen.
+      await expect(page.locator('[data-reminders-headline]')).toContainText('All clear for today')
+      await expect(slot.locator('span[aria-label*="considered"]')).toHaveText('2 of 2')
+
+      // And the surface is still listening: a thought created elsewhere still
+      // reaches the headline. A refresh held behind a row that never reported
+      // itself gone would drop it in silence. Read from the headline rather
+      // than the row, since the slot it lands in is the folded one.
+      ids.push(
+        await createReminder(page, {
+          title: 'A thought after the sweep',
+          due_at: soFar.toUTC().toISO(),
+        }),
+      )
+      await expect(page.locator('[data-reminders-headline]')).toContainText('1 waiting so far', {
+        timeout: 15000,
+      })
+    } finally {
+      await deleteTasks(page, ids)
+    }
+  })
+
+  test('two fast Enters on a focused row consider it once', async ({ authenticatedPage: page }) => {
+    // Focus stays on a row while it collapses, so a second Enter inside those
+    // 180ms would ask for a second completion — and a recurring reminder would
+    // advance two occurrences for one intention. The events are dispatched
+    // rather than pressed because the point is the pair arriving faster than a
+    // re-render, which is the case only the in-flight guard can catch.
+    const ids = [
+      await createReminder(page, {
+        title: 'A thought Entered twice',
+        rrule: 'FREQ=DAILY;BYHOUR=7;BYMINUTE=0',
+        due_at: todayAt(7),
+      }),
+      await createReminder(page, { title: 'The thought after it', due_at: todayAt(7) }),
+    ]
+    const completions = async (id: number) =>
+      (await (await page.request.get(`/api/tasks/${id}`)).json()).data.completion_count
+
+    try {
+      await openReminders(page)
+      await openAllSlots(page)
+      const row = page.locator(`li[data-reminder-id="${ids[0]}"]`)
+      await row.focus()
+      await row.dispatchEvent('keydown', { key: 'Enter' })
+      await row.dispatchEvent('keydown', { key: 'Enter' })
+
+      await expect(page.locator(`li[data-reminder-id="${ids[0]}"]`)).toHaveCount(0)
+      await expect.poll(() => completions(ids[0])).toBe(1)
+
+      // Focus went to the next row rather than falling to <body>, so the next
+      // Tab does not start again from the top of the page.
+      await expect
+        .poll(() => page.evaluate(() => document.activeElement?.getAttribute('data-reminder-id')))
+        .toBe(String(ids[1]))
+
+      await toastUndo(page).click()
+      await expect(page.locator(`li[data-reminder-id="${ids[0]}"]`)).toBeVisible()
+      await expect.poll(() => completions(ids[0])).toBe(0)
+    } finally {
+      await deleteTasks(page, ids)
+    }
+  })
+
   test('?reminder=<id> brings that thought on screen without opening it', async ({
     authenticatedPage: page,
   }) => {

--- a/tests/e2e/reminders.spec.ts
+++ b/tests/e2e/reminders.spec.ts
@@ -351,6 +351,58 @@ test.describe('Reminders surface', () => {
     }
   })
 
+  test('a double-click considers one reminder, never the one beneath it', async ({
+    authenticatedPage: page,
+  }) => {
+    // The regression this pins: a considered row used to leave the list on the
+    // click, so the list reflowed under a pointer that had not moved and the
+    // second click of a double-click landed on whichever thought had slid up
+    // into the gap. Measured on dev at the time: one double-click, two
+    // reminders considered. The row now holds its place, struck through and
+    // inert, until its collapse animation ends.
+    const ids = [
+      await createReminder(page, { title: 'One of a close pair', due_at: todayAt(7) }),
+      await createReminder(page, { title: 'The other of the pair', due_at: todayAt(7) }),
+    ]
+    const completions = async (id: number) =>
+      (await (await page.request.get(`/api/tasks/${id}`)).json()).data.completion_count
+
+    try {
+      await openReminders(page)
+      await openAllSlots(page)
+      const rows = page.locator('li[data-reminder-id]')
+      const slot = page.locator('[data-slot-group]', { hasText: 'The other of the pair' })
+      const counter = slot.locator('span[aria-label*="considered"]')
+      await expect(counter).toHaveText('0 of 2')
+
+      // Whichever is drawn first — the survivor is the other one, and which is
+      // which does not matter to the point being made.
+      const firstId = Number(await rows.first().getAttribute('data-reminder-id'))
+      const survivorId = ids.find((id) => id !== firstId) as number
+
+      await rows.first().dblclick()
+
+      // Exactly one left, and the counter agrees.
+      await expect(page.locator(`li[data-reminder-id="${firstId}"]`)).toHaveCount(0)
+      await expect(counter).toHaveText('1 of 2')
+      await expect(page.locator(`li[data-reminder-id="${survivorId}"]`)).toBeVisible()
+      // The second click did not select it either.
+      await expect(page.locator(`li[data-reminder-id="${survivorId}"]`)).toHaveAttribute(
+        'aria-selected',
+        'false',
+      )
+      // And the server was only ever asked once.
+      await expect.poll(() => completions(firstId)).toBe(1)
+      expect(await completions(survivorId)).toBe(0)
+
+      await toastUndo(page).click()
+      await expect(page.locator(`li[data-reminder-id="${firstId}"]`)).toBeVisible()
+      await expect(counter).toHaveText('0 of 2')
+    } finally {
+      await deleteTasks(page, ids)
+    }
+  })
+
   test('?reminder=<id> brings that thought on screen without opening it', async ({
     authenticatedPage: page,
   }) => {
@@ -1208,6 +1260,44 @@ test.describe('Reminder details', () => {
       expect(after).toEqual(before)
     } finally {
       await deleteTasks(page, [morning, evening])
+    }
+  })
+})
+
+/**
+ * The row is removed from the list by its collapse animation's `animationend`,
+ * never by a timer — so the event has to fire even when the animation has been
+ * reduced to nothing. This drives exactly that: with reduced motion on, a
+ * considered thought must still leave the slot.
+ */
+test.describe('Reminders with reduced motion', () => {
+  test('a considered row still leaves the list with animations off', async ({
+    authenticatedPage: page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    const ids = [
+      await createReminder(page, { title: 'A thought considered quietly', due_at: todayAt(7) }),
+      await createReminder(page, { title: 'A thought that stays put', due_at: todayAt(7) }),
+    ]
+    try {
+      await openReminders(page)
+      await openAllSlots(page)
+      const row = (title: string) => page.locator('li[data-reminder-id]', { hasText: title })
+
+      await row('A thought considered quietly').click()
+      await expect(row('A thought considered quietly')).toHaveCount(0)
+      await expect(row('A thought that stays put')).toBeVisible()
+      await expect(
+        page.getByText('Considered \u201cA thought considered quietly\u201d'),
+      ).toBeVisible()
+
+      // The surface still refreshes afterwards — a row that never reported
+      // itself gone would have held the refresh shut.
+      await toastUndo(page).click()
+      await expect(row('A thought considered quietly')).toBeVisible()
+    } finally {
+      await page.emulateMedia({ reducedMotion: 'no-preference' })
+      await deleteTasks(page, ids)
     }
   })
 })


### PR DESCRIPTION
## What

On the **Reminders** page, the interaction model becomes the one Trent ruled on 2026-09-11:

> "I should be able to just tap reminders pretty much anywhere to mark them done. I can press and hold any item to turn on select mode, a little bit like the way tasks are set up… If you want to actually get the details, I guess we just tap and hold and then click Details with the item checked."

- **Tap anywhere on a row = considered.** It calls exactly what the circle calls — same optimistic path, same Undo toast, no second completion route. The circle stays.
- **Press and hold (~400ms, mouse or touch) enters selection mode**, with the circle swapped for a check mark, the same floating bar as before, and the same `useLongPress` hook `TaskRow` uses on the dashboard. The click the browser synthesises after a hold is swallowed, so a hold never also considers what it just selected.
- **Details = hold, then Details in the bar.** Double-click-to-open and click-to-select are gone. `fromRowControl` still guards the inner buttons.
- Shift-click and Cmd/Ctrl-click still reach a selection with a mouse without the wait; Escape still clears.
- **Keyboard:** the row is the tab stop, Enter/Space is the tap (or the checkbox once selection mode is on), and **Cmd/Ctrl+Enter opens that reminder's details** — a press-and-hold has no keyboard equivalent, so the row offers the destination directly rather than making a keyboard user assemble a selection first.
- The "Not today" fold and the "Considered all" sweeps are unchanged.

Second item, for the iOS widget (widget side is a separate change): **`/reminders?reminder=<id>`** scrolls the row into view and flashes it once, opening its slot — or the "Not today" fold — if that is what is hiding it, then strips the param with a raw history rewrite. It deliberately does **not** open the editor: a widget tap is a request to see the thought in its place.

## Why

A reminder is a prompted thought, and the only thing a user does with one is have it. Making the whole row the "I've had it" target removes the aim at a 24px circle, which was the friction on a 68-row corpus. Selection is the rarer intent, so it moves behind the gesture the dashboard already uses for exactly that.

### One deliberate deviation from `TaskRow`

A plain click **inside** selection mode toggles rather than replacing the selection (`selectOnly`). On the dashboard a replace costs one click to undo; here it can drop the user out of selection mode entirely, and the very next tap would consider the thought. Commented at the call site.

## How verified

- `npm run type-check` clean; `npm run lint` — 0 errors, **no new warnings** (identical warning list to `main`, only two pre-existing `max-lines-per-function` counts grew).
- `npm test` — 1074 passed / 60 files.
- `npm run test:integration` — 260 passed / 27 files.
- `npm run test:e2e` — **66 passed, 0 failed, 0 flaky.** `tests/e2e/reminders.spec.ts` rewritten, not deleted: tap completes and Undo restores, hold enters selection mode with check marks, Details from the bar opens the editor, a plain click in selection mode toggles, Escape clears, and `?reminder=<id>` scrolls + highlights + strips the param without opening a dialog (covering both an in-slot row and one behind the "Not today" fold). The long press is held open by an `expect` on the row going `aria-selected`, never a `waitForTimeout`; the old "double-click lands on the bar" hazard case is removed because nothing summons the bar on a first click any more.
- Deployed to **dev** (https://tasks-dev.tk11.mcnitt.io) and driven with Playwright against the real ~68-reminder corpus at **1280x800** and **375x812** (the phone viewport using a real touch hold via CDP `Input.dispatchTouchEvent`, so the touch path is what was exercised): tap-complete with the Undo toast, hold → selection bar → Details → editor, and the `?reminder=` highlight. No console errors or warnings, no failed requests beyond navigation `ERR_ABORTED`s. The dev corpus was left exactly as found (headline back to "55 waiting so far · 0 of 66 considered").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Revision — `bed112a`: a considered row holds its place until it has gone

Widening the tap target to the whole row turned a latent hazard into a likely one, and it was worth fixing rather than flagging: Trent used double-click on this surface for months to open details, so muscle memory will fire it on day one.

**The bug.** Completion removed the row from `groups` synchronously, so the list reflowed under a pointer that had not moved — the second click of a double-click landed on whichever thought had slid up into the gap and considered that one too. Measured on dev before the fix: **one double-click, two reminders considered** (headline 55 → 53).

**The mechanism.** A considered row now stays exactly where it is — filled green check, struck through, dimmed, `aria-disabled`, out of the tab order, `pointer-events: none` — while it collapses. It leaves `groups` on the row's own `animationend`, **never on a timer**, so the animation and the data cannot disagree; it also leaves on unmount, so a row taken off screen mid-collapse (a folded slot, a navigation) can never be left half-gone or hold the surface's refresh shut. The keyframes hold full height through the first half of the 180ms, which is what makes a fast second click land on the inert row rather than on its neighbour. `refresh` is held while anything is collapsing and run by the last row to leave — a server payload no longer lists a row that is still on screen, and holding for one animation beats guessing where to re-insert it. A failed completion clears the collapse in place rather than re-inserting anything.

**Measured after, on dev:** one double-click removes **one** reminder (55 → 54); one **touch** double-tap at 375px removes **one**. Rows on screen during the collapse: 60 before, 60 during. Mid-collapse DOM state at both viewports: `data-reminder-leaving`, `aria-disabled="true"`, `tabindex="-1"`, `pointer-events: none`.

**Reduced motion:** `animation-duration: 0s`, `animation-name: reminder-leaving`, and `animationend` still fires — confirmed end to end on dev (`prefers-reduced-motion: reduce` matched, row left the list, the surface kept refreshing afterwards). No `requestAnimationFrame` fallback was needed. Pinned by a new E2E test using `page.emulateMedia`.

**Also:** the circle button is now `tabIndex={-1}` — the row is the tab stop and Enter/Space on it does exactly what the circle does, so a second stop per row was duplication on a surface that holds seventy of them.

**Re-verified:** `type-check` clean; `lint` 0 errors and **no new warnings** (the extracted `ReminderRowMarker` keeps `ReminderRow` under the line and complexity limits); `npm test` 1074; `test:integration` 260; `test:e2e` **68 passed, 0 failed, 0 flaky** (two new tests: a `dblclick` considers exactly one reminder with the neighbour untouched and its `completion_count` still 0, and a considered row still leaves the list with animations off). Redeployed to dev; the corpus is back to "55 waiting so far · 0 of 66 considered" with nothing missing; no console errors/warnings and no failed requests.

One note: during this work the E2E run initially failed because a stale `.next` CSS cache was serving pre-change `globals.css` — the Playwright web server reuses that directory. `rm -rf .next` fixed it; no code was involved. Worth knowing if CSS-dependent E2E ever looks impossible.


---

## Revision 2 — `95d8086`: only a row that is on screen may hold the surface open

Fresh-eyes review found three ways the held refresh could be held **forever**, all the same gap: it is released by a *mounted* row whose leaving animation *actually runs*.

**1. Stacked animations (HIGH).** `animation` is one property, and three classes set it on a row — `animate-reminder-leaving`, `animate-ai-processing`, `animate-row-highlight`. tailwind-merge does not dedupe these (only `none/spin/ping/pulse/bounce` are in its animate group) and the other two are defined later in `globals.css`, so they won the cascade. A tapped reminder carrying `ai-to-process` — which the quick add puts on everything it creates, and which enrichment keeps after a first failure — sat struck through, inert and pulsing forever; its id stayed in `leavingIdsRef`, so `refresh()` became a silent no-op for the rest of the session (sync events, undo, put-back, create, focus refetch, all dropped). A leaving row now gets the leaving animation and nothing else, in one extracted `reminderRowClasses()` that says why. The flash also clears itself on its own `animationend`, which additionally fixes a deep-linked row re-flashing *and dragging the viewport back to itself* on any remount (fold/unfold, search-and-clear).

**2. Sweeps reach rows that are not rendered (MED-HIGH).** "Considered all so far" takes every started slot including folded ones, and a folded slot renders no rows to report anything. Rows now register themselves while mounted (`registerRow`); `completeIds` holds a place only for ids that have a row, and commits everything off-screen immediately — nothing is reflowing under a pointer there. A later slot capped at `SLOT_PREVIEW_COUNT` self-heals through the same path.

**3. No in-flight guard (MED).** Two Enters inside the 180ms collapse — focus stays on the row, `tabindex` going to `-1` does not move it — sent `POST /done` twice and advanced a recurring reminder two occurrences. `completeIds` now filters ids already in `pendingIdsRef`, the keyboard handler bails while `completing`, and the toast counts what was actually sent rather than what was asked for (so a sweep confirmed over a collapsing row can't lie either).

**Also folded in:** a failed completion releases a refresh held behind it instead of stranding it, and takes back `consideredAny` if it was the first; the `?reminder=` deep link waits on a fetch that resolved *on this mount* (`hydrated`) rather than trusting the warm module cache, mirroring the dashboard's refusal to resolve `?task=` against a list it can't trust; and Enter hands focus to the next row (else the previous, else the slot header) instead of dropping it on `<body>`. The nine row callbacks became one `ReminderRowHandlers` object — the chain is three components deep and had already drifted once.

**Verified on dev** (`.tmp/remtap3-*`): an `ai-to-process` row tapped leaves the list struck-through-in-place and a reminder created afterwards still arrives (proof the refresh was released); sweeping the Evening slot took **all 11 with only 5 rows rendered**, header `11 later` → `11 of 11`, and the surface kept refreshing. Corpus restored to "55 waiting so far · 0 of 66 considered", 60 rows — identical to before. No console errors/warnings, no failed requests.

**Suites:** `type-check` clean; `lint` 0 errors and **no new warnings**; `npm test` **1074**; `test:integration` **260**; `test:e2e` **71 passed, 0 failed, 0 flaky** — three new tests: tapping an `ai-to-process` row leaves and a later create still reaches the surface; a sweep over a folded slot moves the counters and the headline and leaves the refresh alive; two dispatched Enters inside the collapse give `completion_count` 1 and focus lands on the next row.
